### PR TITLE
boss crystal cutscene fix (should smooth vulnerability phase too)

### DIFF
--- a/Content/Bosses/VitricBoss/NPCs.VitricBossCrystal.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBossCrystal.cs
@@ -20,6 +20,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
     {
         public Vector2 StartPos;
         public Vector2 TargetPos;
+        public Vector2 prevTargetPos;
         public VitricBoss Parent;
 		public bool shouldDrawArc;
 
@@ -108,11 +109,13 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
         public override void SendExtraAI(BinaryWriter writer)
         {
+            writer.WritePackedVector2(StartPos);
             writer.WritePackedVector2(TargetPos);
         }
 
         public override void ReceiveExtraAI(BinaryReader reader)
         {
+            StartPos = reader.ReadPackedVector2();
             TargetPos = reader.ReadPackedVector2();
         }
 
@@ -350,8 +353,9 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     break;
             }
 
-            if (Main.netMode == NetmodeID.Server && (phase != prevPhase || state != prevState))
+            if (Main.netMode == NetmodeID.Server && (phase != prevPhase || state != prevState || TargetPos != prevTargetPos))
             {
+                prevTargetPos = TargetPos;
                 prevPhase = phase;
                 prevState = state;
                 npc.netUpdate = true;


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
cieros boss crystals were not synced for the cutscene
### What are the implementation specifics of this change? Are there any consequences?
they weren't sending their startPos so the other clients were using some random values in place of them