### PR TITLE
boss spawner holder mp fix

### DIFF
--- a/Content/Tiles/Vitric/Temple/BossSpawnerHolder.cs
+++ b/Content/Tiles/Vitric/Temple/BossSpawnerHolder.cs
@@ -34,7 +34,7 @@ namespace StarlightRiver.Content.Tiles.Vitric.Temple
         public override bool NewRightClick(int i, int j)
         {
             WorldGen.KillTile(i, j);
-            Item.NewItem(Main.LocalPlayer.Center, ItemType<Items.Vitric.GlassIdolPremiumEdition>());
+            Main.LocalPlayer.QuickSpawnItem(ItemType<Items.Vitric.GlassIdolPremiumEdition>());
 
             return true;
         }


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
This is to fix the premium glass idol holder which previously would not drop the idol in multiplayer

### What are the implementation specifics of this change? Are there any consequences?
changed the item summoning to a quickspawn which is mp compatible.