### PR TITLE
Fix for constant index out of bounds in demo world.

### DIFF
--- a/Content/WorldGeneration/WorldgenWorld.cs
+++ b/Content/WorldGeneration/WorldgenWorld.cs
@@ -41,6 +41,9 @@ namespace StarlightRiver.Core
         {
             isDemoWorld = true;
 
+            //dirty hack where we force the old man into existence in the demo world so that he doesn't constantly try to spawn in the non-existant dungeon and cause index out of bounds errors TODO: make sure this is removed if the dungeon is being generated in the future
+            NPC.NewNPC(64, 64, Terraria.ID.NPCID.OldMan);
+
             if (WorldGen.genRand.NextBool())
                 Flag(WorldFlags.AluminumMeteors);
 


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
This is to fix the index out of bounds errors that the demo world experiences. It is caused by the Old Man attempting to spawn into a world that doesn't have a dungeon.

### What are the implementation specifics of this change? Are there any consequences?
The specific solution is to force spawn the old man into the top left of the world when the world is generated. The code for this will need to be removed when this branch starts generating a dungeon. Another idea considered was to murder the Old Man as he spawned before the conveyor belt collisions are checked but since there's no obvious hooks on vanilla spawns like there are for mod spawns I went with this, + its more compatible if someone decides to generate a normal world before loading the demo in.