### PR TITLE
Fix for ability pickup not spawning on server

### DIFF
--- a/Content/Packets/SpawnNPCPacket.cs
+++ b/Content/Packets/SpawnNPCPacket.cs
@@ -30,6 +30,9 @@ namespace StarlightRiver.Packets
                 int n = NPC.NewNPC(x, y, type);
                 NetMessage.SendData(Terraria.ID.MessageID.SyncNPC, -1, -1, null, n);
             }
+
+            if (Main.netMode == Terraria.ID.NetmodeID.SinglePlayer)
+                NPC.NewNPC(x, y, type);
         }
     }
 }

--- a/Content/Pickups/AbilityPickupTile.cs
+++ b/Content/Pickups/AbilityPickupTile.cs
@@ -9,6 +9,7 @@ namespace StarlightRiver.Pickups
     {
         public virtual int PickupType => 0;
 
+        private int spawnAttemptTimer = 0;
         public override bool Autoload(ref string name, ref string texture)
         {
             texture = AssetDirectory.Invisible;
@@ -23,13 +24,22 @@ namespace StarlightRiver.Pickups
 
         public override void NearbyEffects(int i, int j, bool closer)
         {
+            if (spawnAttemptTimer > 0)
+            {
+                spawnAttemptTimer--;
+                return;
+            }
+            spawnAttemptTimer = 60;
+
             for (int k = 0; k < Main.maxNPCs; k++)
             {
                 NPC npc = Main.npc[k];
-                if (npc.active && npc.type == PickupType && Vector2.DistanceSquared(npc.position, new Vector2(i, j) * 16) <= 128) return;
+                if (npc.active && npc.type == PickupType && Vector2.DistanceSquared(npc.position, new Vector2(i, j) * 16) <= 128)
+                    return;
             }
 
-            NPC.NewNPC(i * 16 + 8, j * 16 + 24, PickupType);
+            Packets.SpawnNPC abilitySpawnPacket = new Packets.SpawnNPC(Main.myPlayer, i * 16 + 8, j * 16 + 24, PickupType);
+            abilitySpawnPacket.Send();
         }
     }
 }


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?

in multiplayer each client would create a local clientside version of the ability pickup, causing the player to ride random npcs that overwrite the clientside pickup if the player picked up the ability very quick after world load

### What are the implementation specifics of this change? Are there any consequences?

should be better all around and more deterministic since the whoami is synced on all clients and server, also included a cooldown timer on the ability spawn so it wouldn't need to be checked every frame