### PR TITLE
Bug fixes from large multiplayer test

### DIFF
--- a/Content/Abilities/AbilityHandler.cs
+++ b/Content/Abilities/AbilityHandler.cs
@@ -14,7 +14,7 @@ using Terraria.ModLoader.IO;
 
 namespace StarlightRiver.Content.Abilities
 {
-	public partial class AbilityHandler : ModPlayer, ILoadable
+	public class AbilityHandler : ModPlayer, ILoadable
     {
         // The player's active ability.
         public Ability ActiveAbility
@@ -73,6 +73,15 @@ namespace StarlightRiver.Content.Abilities
         private Ability nextAbility;
 
         public float Priority => 1;
+
+        //for some reason without specifically setting these values to zero with cloneNewInstances => false and contructor,
+        ////on a server if someone unlocks or modifies these it will impact newly created characters from then on for that instance
+        public override bool CloneNewInstances => false;
+        public AbilityHandler()
+        {
+            infusions = new InfusionItem[Infusion.InfusionSlots];
+            unlockedAbilities = new Dictionary<Type, Ability>();
+        }
 
         public void Load()
 		{
@@ -237,9 +246,9 @@ namespace StarlightRiver.Content.Abilities
                 // Load max infusions
                 InfusionLimit = tag.GetInt(nameof(InfusionLimit));
             }
-            catch
+            catch (Exception e)
             {
-
+                StarlightRiver.Instance.Logger.Debug("handled error loading player: " + e);
             }
         }
 

--- a/Content/Abilities/AbilityHelper.cs
+++ b/Content/Abilities/AbilityHelper.cs
@@ -11,23 +11,31 @@ namespace StarlightRiver.Content.Abilities
     {
         public static bool CheckDash(Player player, Rectangle hitbox)
         {
-            if (!player.active) return false;
+            if (!player.active) 
+                return false;
             return player.ActiveAbility<Dash>() && Collision.CheckAABBvAABBCollision(player.Hitbox.TopLeft(), player.Hitbox.Size(), hitbox.TopLeft(), hitbox.Size());
         }
 
         public static bool CheckWisp(Player player, Rectangle hitbox)
         {
-            if (!player.active) return false;
+            if (!player.active) 
+                return false;
             return player.ActiveAbility<Wisp>() && Collision.CheckAABBvAABBCollision(player.Hitbox.TopLeft(), player.Hitbox.Size(), hitbox.TopLeft(), hitbox.Size());
         }
 
         public static bool CheckSmash(Player player, Rectangle hitbox)
         {
-            if (!player.active) return false;
+            if (!player.active) 
+                return false;
             return player.ActiveAbility<Smash>() && Collision.CheckAABBvAABBCollision(player.Hitbox.TopLeft(), player.Hitbox.Size(), hitbox.TopLeft(), hitbox.Size());
         }
 
-        public static bool UsingAnyAbility(this Player player) => player.GetHandler().ActiveAbility != null;
+        public static bool UsingAnyAbility(this Player player)
+        {
+            if (!player.active) 
+                return false;
+            return player.GetHandler().ActiveAbility != null;
+        }
 
         public static bool ActiveAbility<T>(this Player player) where T : Ability => player.GetHandler().ActiveAbility is T;
 

--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.Attacks.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.Attacks.cs
@@ -28,7 +28,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             List<int> players = new List<int>();
 
-            foreach (Player player in Main.player.Where(n => n.active && arena.Contains(n.Center.ToPoint()) ))
+            foreach (Player player in Main.player.Where(n => n.active && !n.dead && arena.Contains(n.Center.ToPoint()) ))
             {
                 players.Add(player.whoAmI);
             }

--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.Cutscenes.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.Cutscenes.cs
@@ -18,11 +18,14 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 {
 	public sealed partial class VitricBoss : ModNPC
 	{
+        private bool IsInsideArena()
+        {
+            //certain client side effects should only happen when player is in arena (or everywhere in single player)
+            //and not occur for the server
+            return Main.netMode == NetmodeID.SinglePlayer || Main.LocalPlayer.Hitbox.Intersects(arena);
+        }
         private void SpawnAnimation() //The animation which plays when the boss is spawning
         {
-            if (Main.netMode == NetmodeID.MultiplayerClient && !Main.LocalPlayer.Hitbox.Intersects(arena))
-                return;  //mp player not in arena so we can just skip
-
             rotationLocked = true;
             lockedRotation = 1.57f;
 
@@ -32,9 +35,12 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 RandomizeTarget(); //pick a random target so the eyes will follow them
                 startPos = npc.Center;
 
-                StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
-                mp.ScreenMoveTarget = npc.Center + new Vector2(0, -600);
-                mp.ScreenMoveTime = 650;
+                if (IsInsideArena()) 
+                {
+                    StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
+                    mp.ScreenMoveTarget = npc.Center + new Vector2(0, -600);
+                    mp.ScreenMoveTime = 650;
+                }
 
                 music = mod.GetSoundSlot(SoundType.Music, "Sounds/Music/VitricBossAmbient");
 
@@ -53,16 +59,19 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             if (GlobalTimer == 120)
             {
-                StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
-                mp.Shake += 10;
+                if (IsInsideArena())
+                {
+                    StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
+                    mp.Shake += 10;
+
+                    ZoomHandler.SetZoomAnimation(1.1f, 60);
+                }
 
                 for (int k = 0; k < 10; k++)
                     Gore.NewGorePerfect(arena.Center() + new Vector2(Main.rand.Next(-600, 600), -450), Vector2.UnitY * Main.rand.NextFloat(-1, 2), ModGore.GetGoreSlot(AssetDirectory.VitricBoss + "Gore/Cluster" + Main.rand.Next(1, 19)));
 
                 for (int k = 0; k < 20; k++)
                     Dust.NewDustPerfect(arena.Center() + new Vector2(Main.rand.Next(-600, 600), -450), DustID.Stone, Vector2.UnitY * Main.rand.NextFloat(6, 12), 0, default, Main.rand.NextFloat(1, 3));
-
-                ZoomHandler.SetZoomAnimation(1.1f, 60);
             }
 
             if (GlobalTimer == 210)
@@ -71,16 +80,19 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             if (GlobalTimer == 240)
             {
-                StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
-                mp.Shake += 20;
+                if(IsInsideArena())
+                {
+                    StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
+                    mp.Shake += 20;
+
+                    ZoomHandler.SetZoomAnimation(1.2f, 60);
+                }
 
                 for (int k = 0; k < 10; k++)
                     Gore.NewGorePerfect(arena.Center() + new Vector2(Main.rand.Next(-600, 600), -450), Vector2.UnitY * Main.rand.NextFloat(-1, 2), ModGore.GetGoreSlot(AssetDirectory.VitricBoss + "Gore/Cluster" + Main.rand.Next(1, 19)));
 
                 for (int k = 0; k < 20; k++)
                     Dust.NewDustPerfect(arena.Center() + new Vector2(Main.rand.Next(-600, 600), -450), DustID.Stone, Vector2.UnitY * Main.rand.NextFloat(6, 12), 0, default, Main.rand.NextFloat(1, 3));
-
-                ZoomHandler.SetZoomAnimation(1.2f, 60);
             }
 
             if (GlobalTimer == 330)
@@ -89,16 +101,19 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             if (GlobalTimer == 360)
             {
-                StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
-                mp.Shake += 25;
+                if (IsInsideArena())
+                {
+                    StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
+                    mp.Shake += 25;
+
+                    ZoomHandler.SetZoomAnimation(1.3f, 60);
+                }
 
                 for (int k = 0; k < 10; k++)
                     Gore.NewGorePerfect(arena.Center() + new Vector2(Main.rand.Next(-600, 600), -450), Vector2.UnitY * Main.rand.NextFloat(-1, 2), ModGore.GetGoreSlot(AssetDirectory.VitricBoss + "Gore/Cluster" + Main.rand.Next(1, 19)));
 
                 for (int k = 0; k < 20; k++)
                     Dust.NewDustPerfect(arena.Center() + new Vector2(Main.rand.Next(-600, 600), -450), DustID.Stone, Vector2.UnitY * Main.rand.NextFloat(6, 12), 0, default, Main.rand.NextFloat(1, 3));
-
-                ZoomHandler.SetZoomAnimation(1.3f, 60);
             }
 
             if (GlobalTimer == 424)
@@ -112,8 +127,11 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 if(Main.netMode != NetmodeID.Server)
                     UILoader.GetUIState<TextCard>().Display(npc.FullName, Main.rand.Next(10000) == 0 ? "Glass tax returns" : "Shattered Sentinel", null, 310, 1.25f); //intro text
 
-                StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
-                mp.Shake += 30;
+                if (IsInsideArena())
+                {
+                    StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
+                    mp.Shake += 30;
+                }
 
                 ZoomHandler.SetZoomAnimation(Main.GameZoomTarget, 20);
 
@@ -143,7 +161,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     if (GlobalTimer == 540 + k * 5)
                     {
                         Vector2 target = new Vector2(npc.Center.X, StarlightWorld.VitricBiome.Top * 16 + 1180);
-                        int index = NPC.NewNPC((int)target.X, (int)target.Y, NPCType<VitricBossCrystal>(), 0, 2); //spawn in state 2: sandstone forme
+                        int index = NPC.NewNPC((int)target.X, (int)target.Y, NPCType<VitricBossCrystal>(), 0, 2); //spawn in state 2: sandstone form
                         (Main.npc[index].modNPC as VitricBossCrystal).Parent = this;
                         (Main.npc[index].modNPC as VitricBossCrystal).StartPos = target;
                         (Main.npc[index].modNPC as VitricBossCrystal).TargetPos = npc.Center + new Vector2(0, -180).RotatedBy(6.28f / 4 * k);
@@ -176,8 +194,11 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             if (GlobalTimer == 620)
 			{
-                StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
-                mp.Shake += 60;
+                if (IsInsideArena())
+                {
+                    StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
+                    mp.Shake += 60;
+                }
 
                 if (Main.netMode != NetmodeID.Server)
                     Filters.Scene.Deactivate("Shockwave");
@@ -211,13 +232,16 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 ResetAttack();
                 npc.netUpdate = true;
             }
+
+            if (justRecievedPacket && prevTickGlobalTimer < GlobalTimer - 1)
+            {
+                prevTickGlobalTimer++;
+                SpawnAnimation(); //recursive call through this function when skipping ticks to make sure music or other sounds arent lost in mp
+            }
         }
 
 		private void PhaseTransitionAnimation() //The animation that plays when the boss transitions from phase 1 to 2
 		{
-            if (Main.netMode == NetmodeID.MultiplayerClient && !Main.LocalPlayer.Hitbox.Intersects(arena))
-                return;  //mp player not in arena so we can just skip
-
             rotationLocked = true;       
 
             if (GlobalTimer == 2)
@@ -240,14 +264,18 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 SetFrameX(1);
                 npc.friendly = true; //so we wont get contact damage
 
-                StarlightPlayer mp2 = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
-                mp2.ScreenMoveTarget = arena.Center();
-                mp2.ScreenMoveTime = 480;
+                if (IsInsideArena())
+                {
+                    StarlightPlayer mp2 = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
+                    mp2.ScreenMoveTarget = arena.Center();
+                    mp2.ScreenMoveTime = 480;
+                }
             }
 
             if (GlobalTimer > 140 && GlobalTimer < 400)
             {
-                ZoomHandler.AddFlatZoom(0.2f);
+                if (IsInsideArena())
+                    ZoomHandler.AddFlatZoom(0.2f);
             }
 
             if (GlobalTimer > 20 && GlobalTimer < 140)
@@ -306,8 +334,11 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             if (GlobalTimer == 360)
             {
-                StarlightPlayer mp2 = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
-                mp2.Shake += 40;
+                if (IsInsideArena())
+                {
+                    StarlightPlayer mp2 = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
+                    mp2.Shake += 40;
+                }
 
                 for (int k = 0; k < 40; k++)
                 {
@@ -337,13 +368,16 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
                 Vignette.visible = true;
             }
+
+            if (justRecievedPacket && prevTickGlobalTimer < GlobalTimer - 1)
+            {
+                prevTickGlobalTimer++;
+                PhaseTransitionAnimation(); //recursive call through this function when skipping ticks to make sure music or other sounds arent lost in mp
+            }
         }
 
         private void DeathAnimation() //The animation that plays when the boss dies
         {
-            if (Main.netMode == NetmodeID.MultiplayerClient && !Main.LocalPlayer.Hitbox.Intersects(arena))
-                return;  //mp player not in arena so we can just skip
-
             Vignette.offset = Vector2.Zero;
             Vignette.opacityMult = 0.5f + Math.Min(GlobalTimer / 60f, 0.5f);
 
@@ -379,8 +413,11 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             if (GlobalTimer == 120 && Main.netMode != NetmodeID.Server)
             {
-                StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
-                mp.Shake += 60;
+                if (IsInsideArena())
+                {
+                    StarlightPlayer mp = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
+                    mp.Shake += 60;
+                }
 
                 Main.PlaySound(SoundID.Roar, npc.Center, 0);
 
@@ -441,6 +478,12 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
                 Vignette.visible = false;
                 npc.Kill();
+            }
+
+            if (justRecievedPacket && prevTickGlobalTimer < GlobalTimer - 1)
+            {
+                prevTickGlobalTimer++;
+                DeathAnimation(); //recursive call through this function when skipping ticks to make sure music or other sounds arent lost in mp
             }
         }
 	}

--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.Cutscenes.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.Cutscenes.cs
@@ -24,12 +24,20 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
             //and not occur for the server
             return Main.netMode == NetmodeID.SinglePlayer || Main.LocalPlayer.Hitbox.Intersects(arena);
         }
+
+        private bool checkSpecificTime(int time)
+        {
+            //if the globaltimer gets fastforwarded from recieving a packet (generally rare to skip)
+            //we want to make sure we still perform all the specific timer increments so things aren't lost like assigning the music or other effects
+            //possible to reverse a few ticks aswell but thats generally safe and the worst that happens is doubling up on screenshake since a few frames of offset duplicate sound effects is indistinguishable
+            return (GlobalTimer == time || (justRecievedPacket && prevTickGlobalTimer < time && GlobalTimer > time));
+        }
         private void SpawnAnimation() //The animation which plays when the boss is spawning
         {
             rotationLocked = true;
             lockedRotation = 1.57f;
 
-            if (GlobalTimer == 2)
+            if (checkSpecificTime(2))
             {
                 npc.friendly = true; //so he wont kill you during the animation
                 RandomizeTarget(); //pick a random target so the eyes will follow them
@@ -52,12 +60,12 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 Helper.PlayPitched("VitricBoss/CeirosRumble", 0.4f, 0, npc.Center);
             }
 
-            if (GlobalTimer == 90)
+            if (checkSpecificTime(90))
                 //Helper.PlayPitched("VitricBoss/StoneBreak", 0.25f, 0.3f, npc.Center);
                 Helper.PlayPitched("VitricBoss/ceiroslidclose", 0.35f, 0.4f, npc.Center);
 
 
-            if (GlobalTimer == 120)
+            if (checkSpecificTime(120))
             {
                 if (IsInsideArena())
                 {
@@ -74,11 +82,11 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     Dust.NewDustPerfect(arena.Center() + new Vector2(Main.rand.Next(-600, 600), -450), DustID.Stone, Vector2.UnitY * Main.rand.NextFloat(6, 12), 0, default, Main.rand.NextFloat(1, 3));
             }
 
-            if (GlobalTimer == 210)
+            if (checkSpecificTime(210))
                 //Helper.PlayPitched("VitricBoss/ceiroslidclose", 0.35f, 0.2f, npc.Center);
                 Helper.PlayPitched("VitricBoss/StoneBreak", 0.35f, 0.2f, npc.Center);
 
-            if (GlobalTimer == 240)
+            if (checkSpecificTime(240))
             {
                 if(IsInsideArena())
                 {
@@ -95,11 +103,11 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     Dust.NewDustPerfect(arena.Center() + new Vector2(Main.rand.Next(-600, 600), -450), DustID.Stone, Vector2.UnitY * Main.rand.NextFloat(6, 12), 0, default, Main.rand.NextFloat(1, 3));
             }
 
-            if (GlobalTimer == 330)
+            if (checkSpecificTime(330))
                 //Helper.PlayPitched("VitricBoss/ceiroslidclose", 0.5f, 0.1f, npc.Center);
                 Helper.PlayPitched("VitricBoss/StoneBreak", 0.5f, 0, npc.Center);
 
-            if (GlobalTimer == 360)
+            if (checkSpecificTime(360))
             {
                 if (IsInsideArena())
                 {
@@ -116,13 +124,13 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     Dust.NewDustPerfect(arena.Center() + new Vector2(Main.rand.Next(-600, 600), -450), DustID.Stone, Vector2.UnitY * Main.rand.NextFloat(6, 12), 0, default, Main.rand.NextFloat(1, 3));
             }
 
-            if (GlobalTimer == 424)
+            if (checkSpecificTime(424))
             {
                 Helper.PlayPitched("VitricBoss/StoneBreak", 0.7f, 0, npc.Center);
                 Helper.PlayPitched("VitricBoss/StoneBreakTwo", 0.7f, 0, npc.Center);
             }
 
-            if (GlobalTimer == 454)
+            if (checkSpecificTime(454))
             {
                 if(Main.netMode != NetmodeID.Server)
                     UILoader.GetUIState<TextCard>().Display(npc.FullName, Main.rand.Next(10000) == 0 ? "Glass tax returns" : "Shattered Sentinel", null, 310, 1.25f); //intro text
@@ -189,10 +197,10 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 }
             }
 
-            if (GlobalTimer == 610)
+            if (checkSpecificTime(610))
                 Helper.PlayPitched("VitricBoss/CeirosRoar", 1, 0, npc.Center);
 
-            if (GlobalTimer == 620)
+            if (checkSpecificTime(620))
 			{
                 if (IsInsideArena())
                 {
@@ -204,7 +212,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     Filters.Scene.Deactivate("Shockwave");
             }
 
-            if(GlobalTimer == 690)
+            if(checkSpecificTime(690))
                 Helper.PlayPitched("VitricBoss/ceiroslidclose", 1, 0, npc.Center);
 
             if (GlobalTimer > 690 && GlobalTimer < 750)
@@ -232,19 +240,13 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 ResetAttack();
                 npc.netUpdate = true;
             }
-
-            if (justRecievedPacket && prevTickGlobalTimer < GlobalTimer - 1)
-            {
-                prevTickGlobalTimer++;
-                SpawnAnimation(); //recursive call through this function when skipping ticks to make sure music or other sounds arent lost in mp
-            }
         }
 
 		private void PhaseTransitionAnimation() //The animation that plays when the boss transitions from phase 1 to 2
 		{
             rotationLocked = true;       
 
-            if (GlobalTimer == 2)
+            if (checkSpecificTime(2))
             {
                 lockedRotation = 3.14f;
 
@@ -259,7 +261,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 crystals[0].ai[2] = 6;
             }
 
-            if (GlobalTimer == 140)
+            if (checkSpecificTime(140))
             {
                 SetFrameX(1);
                 npc.friendly = true; //so we wont get contact damage
@@ -308,7 +310,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 }
             }
 
-            if (GlobalTimer == 325)
+            if (checkSpecificTime(325))
                 Helper.PlayPitched("VitricBoss/StoneBreakTwo", 0.7f, 0, npc.Center);
 
             if (GlobalTimer >= 340 && GlobalTimer < 370)
@@ -322,18 +324,17 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 SetFrameX(4 + (int)((GlobalTimer - 350) / 20f * 6));
             }
 
-            if (GlobalTimer == 350)
+            if (checkSpecificTime(350))
                 foreach (NPC crystal in crystals) //kill all the crystals
                     crystal.Kill();
 
-            if (GlobalTimer == 359) 
+            if (checkSpecificTime(359)) 
                 music = mod.GetSoundSlot(SoundType.Music, "ThisSoundDoesntExist"); //handles the music transition
 
-            if (GlobalTimer == 360)
+            if (checkSpecificTime(360))
+            {
                 music = mod.GetSoundSlot(SoundType.Music, "Sounds/Music/VitricBoss2");
 
-            if (GlobalTimer == 360)
-            {
                 if (IsInsideArena())
                 {
                     StarlightPlayer mp2 = Main.LocalPlayer.GetModPlayer<StarlightPlayer>();
@@ -355,7 +356,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                         };
             }
 
-            if(GlobalTimer == 460)
+            if(checkSpecificTime(460))
                 lockedRotation = 2f;
 
             if (GlobalTimer > 480)
@@ -368,12 +369,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
                 Vignette.visible = true;
             }
-
-            if (justRecievedPacket && prevTickGlobalTimer < GlobalTimer - 1)
-            {
-                prevTickGlobalTimer++;
-                PhaseTransitionAnimation(); //recursive call through this function when skipping ticks to make sure music or other sounds arent lost in mp
-            }
         }
 
         private void DeathAnimation() //The animation that plays when the boss dies
@@ -381,8 +376,10 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
             Vignette.offset = Vector2.Zero;
             Vignette.opacityMult = 0.5f + Math.Min(GlobalTimer / 60f, 0.5f);
 
-            if (GlobalTimer == 1)
+            if (checkSpecificTime(1))
             {
+                Main.PlaySound(mod.GetLegacySoundSlot(SoundType.Custom, "Sounds/VitricBossDeath"));
+
                 startPos = npc.Center;
                 npc.rotation = 0;
 
@@ -392,9 +389,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             if (GlobalTimer > 3 && GlobalTimer <= 100)
                 npc.Center = Vector2.SmoothStep(startPos, homePos, GlobalTimer / 100f);
-
-            if (GlobalTimer == 1)
-                Main.PlaySound(mod.GetLegacySoundSlot(SoundType.Custom, "Sounds/VitricBossDeath"));
 
             if (GlobalTimer > 100 && GlobalTimer < 120 && Main.netMode != NetmodeID.Server)
             {
@@ -411,7 +405,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 Filters.Scene.Activate("Shockwave", npc.Center).GetShader().UseProgress(Main.screenWidth / (float)Main.screenHeight).UseIntensity(300 - (int)(Math.Sin(progress * 3.14f) * 220)).UseDirection(new Vector2(progress * 0.8f, progress * 0.9f));
             }
 
-            if (GlobalTimer == 120 && Main.netMode != NetmodeID.Server)
+            if (checkSpecificTime(120) && Main.netMode != NetmodeID.Server)
             {
                 if (IsInsideArena())
                 {
@@ -429,7 +423,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 SetFrameX((int)(8 - (GlobalTimer - 120) / 40f * 8));
             }
 
-            if(GlobalTimer == 160)
+            if(checkSpecificTime(160))
 			{
                 SetFrameX(2);
                 SetFrameY(0);
@@ -453,7 +447,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
             if (GlobalTimer > 3 && GlobalTimer < 595)
                 Main.musicFade[Main.curMusic] = MathHelper.Clamp(1 - (GlobalTimer - 63) / 60f, 0, 1);
 
-            if (GlobalTimer == 600)
+            if (checkSpecificTime(600))
             {
 
                 if (Main.netMode != NetmodeID.Server)
@@ -478,12 +472,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
                 Vignette.visible = false;
                 npc.Kill();
-            }
-
-            if (justRecievedPacket && prevTickGlobalTimer < GlobalTimer - 1)
-            {
-                prevTickGlobalTimer++;
-                DeathAnimation(); //recursive call through this function when skipping ticks to make sure music or other sounds arent lost in mp
             }
         }
 	}

--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
@@ -663,6 +663,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 npc.netUpdate = true;
             }
 
+            prevTickGlobalTimer = GlobalTimer; //potentially just shifted so we store the previous value in case of fastforwarding
             justRecievedPacket = false; //at end of frame set to no longer just recieved
         }
 
@@ -733,7 +734,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
         public override void ReceiveExtraAI(System.IO.BinaryReader reader)
         {
             justRecievedPacket = true;
-            prevTickGlobalTimer = GlobalTimer; //potentially just shifted so we store the previous value in case of fastforwarding
 
             favoriteCrystal = reader.ReadInt32();
             altAttack = reader.ReadBoolean();

--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
@@ -747,8 +747,5 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
         }
         #endregion Networking
-
-        private int IconFrame = 0;
-        private int IconFrameCounter = 0;
     }
 }

--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
@@ -60,6 +60,9 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
         internal ref float AttackPhase => ref npc.ai[2];
         internal ref float AttackTimer => ref npc.ai[3];
 
+
+        private bool justRecievedPacket = false; //true for the frame this recieves a packet update to handle any syncronizing
+        private float prevTickGlobalTimer; //since globalTimer can jump around from from to frame from recieving packets, we want to make sure we catch logic for every number in the cutscenes if it fastforwarded from a packet (reversed is ignored so we don't double up on sounds/shake)
         private float prevPhase = 0;
         private float prevAttackPhase = 0;
 
@@ -653,13 +656,14 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             body?.UpdateBody(); //update the physics on the body, last, so it can override framing
 
-            if (Main.netMode == NetmodeID.Server && (Phase != prevPhase || AttackPhase != prevPhase))
+            if (Main.netMode == NetmodeID.Server && (Phase != prevPhase || AttackPhase != prevAttackPhase))
             {
                 prevPhase = Phase;
                 prevAttackPhase = AttackPhase;
                 npc.netUpdate = true;
             }
 
+            justRecievedPacket = false; //at end of frame set to no longer just recieved
         }
 
         public void findCrystals()
@@ -711,7 +715,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
         #region Networking
         public override void SendExtraAI(System.IO.BinaryWriter writer)
         {
-
             writer.Write(favoriteCrystal);
             writer.Write(altAttack);
             writer.Write(lockedRotation);
@@ -729,6 +732,9 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
         public override void ReceiveExtraAI(System.IO.BinaryReader reader)
         {
+            justRecievedPacket = true;
+            prevTickGlobalTimer = GlobalTimer; //potentially just shifted so we store the previous value in case of fastforwarding
+
             favoriteCrystal = reader.ReadInt32();
             altAttack = reader.ReadBoolean();
             lockedRotation = reader.ReadSingle();

--- a/Content/CustomHooks/Mechanics.NoBuild.cs
+++ b/Content/CustomHooks/Mechanics.NoBuild.cs
@@ -19,6 +19,7 @@ namespace StarlightRiver.Content.CustomHooks
 		{
             On.Terraria.Player.PickTile += DontPickInZone;
             On.Terraria.WorldGen.PlaceTile += DontManuallyPlaceInZone;
+            On.Terraria.WorldGen.PoundTile += DontPoundTile;
             On.Terraria.WorldGen.PlaceWire += DontPlaceWire;
             On.Terraria.WorldGen.PlaceWire2 += DontPlaceWire2;
             On.Terraria.WorldGen.PlaceWire3 += DontPlaceWire3;
@@ -46,6 +47,16 @@ namespace StarlightRiver.Content.CustomHooks
 
             return false;
         }
+
+        private bool DontPoundTile(On.Terraria.WorldGen.orig_PoundTile orig, int x, int y)
+        {
+            if (IsProtected(x, y))
+            {
+                FailFX(new Point16(x, y));
+                return false;
+            }
+            return orig(x, y);
+        } 
 
 
         private bool DontPlaceWire(On.Terraria.WorldGen.orig_PlaceWire orig, int x, int y)

--- a/Content/CustomHooks/Visuals.LightingBuffer.cs
+++ b/Content/CustomHooks/Visuals.LightingBuffer.cs
@@ -13,8 +13,6 @@ namespace StarlightRiver.Content.CustomHooks
             if (Main.dedServ)
                 return;
 
-            Helpers.LightingBuffer.SetupLightingQuadBuffer();
-
             Main.OnPreDraw += LightingTarget;
             On.Terraria.Main.SetDisplayMode += RefreshLightingTarget;
         }
@@ -26,7 +24,7 @@ namespace StarlightRiver.Content.CustomHooks
 
         private void RefreshLightingTarget(On.Terraria.Main.orig_SetDisplayMode orig, int width, int height, bool fullscreen)
         {
-            if (width != Main.screenWidth || height != Main.screenHeight)
+            if (!Main.gameInactive && width != Main.screenWidth || height != Main.screenHeight)
                 StarlightRiver.LightingBufferInstance.ResizeBuffers(width, height);
 
             orig(width, height, fullscreen);

--- a/Content/GUI/BootlegHealthbar.cs
+++ b/Content/GUI/BootlegHealthbar.cs
@@ -10,7 +10,7 @@ using static Terraria.ModLoader.ModContent;
 
 namespace StarlightRiver.Content.GUI
 {
-    public class BootlegHealthbar : SmartUIState
+    public class BootlegHealthbar : SmartUIState, ILoadable
     {
         public override int InsertionIndex(List<GameInterfaceLayer> layers) => layers.FindIndex(layer => layer.Name.Equals("Vanilla: Mouse Text"));
         public override bool Visible => visible;
@@ -24,12 +24,28 @@ namespace StarlightRiver.Content.GUI
         public int Timer;
 
         private static ParticleSystem.Update UpdateShards => UpdateShardsBody;
-        private static ParticleSystem ShardsSystem = new ParticleSystem("StarlightRiver/Assets/GUI/charm", UpdateShards);
-        private static ParticleSystem ShardsSystem2 = new ParticleSystem("StarlightRiver/Assets/GUI/BossbarBack", UpdateShards);
+
+        
+
+        private static ParticleSystem ShardsSystem;
+        private static ParticleSystem ShardsSystem2;
 
         private Bar bar = new Bar();
 
-		public override void OnInitialize()
+        public float Priority => 1f;
+        public void Load()
+        {
+            ShardsSystem = new ParticleSystem("StarlightRiver/Assets/GUI/charm", UpdateShards);
+            ShardsSystem2 = new ParticleSystem("StarlightRiver/Assets/GUI/BossbarBack", UpdateShards);
+        }
+
+        public void Unload()
+        {
+            ShardsSystem = null;
+            ShardsSystem2 = null;
+        }
+
+        public override void OnInitialize()
 		{
             bar.Left.Set(-258, 0.5f);
             bar.Top.Set(-80, 1);
@@ -116,7 +132,7 @@ namespace StarlightRiver.Content.GUI
             if (tex != default)
                 Texture = tex;
         }
-	}
+    }
 
     public class Bar : UIElement
 	{

--- a/Content/Items/BarrierDye/BaseBarrierDye.cs
+++ b/Content/Items/BarrierDye/BaseBarrierDye.cs
@@ -91,7 +91,7 @@ namespace StarlightRiver.Content.Items.BarrierDye
 			if (player.mount.Active)
 				samplerState = Main.MountedSamplerState;
 
-			Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, samplerState, DepthStencilState.None, Main.instance.Rasterizer, null, Main.Transform);
+			Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, samplerState, DepthStencilState.None, Main.instance.Rasterizer, null, Main.GameViewMatrix.TransformationMatrix);
 		}
 	}
 }

--- a/Content/Items/BaseTypes/CursedAccessory.cs
+++ b/Content/Items/BaseTypes/CursedAccessory.cs
@@ -10,7 +10,7 @@ using Terraria.ModLoader;
 
 namespace StarlightRiver.Content.Items.BaseTypes
 {
-	public abstract class CursedAccessory : SmartAccessory
+	public abstract class CursedAccessory : SmartAccessory, ILoadable
     {
         public static readonly Color CurseColor = new Color(25, 17, 49);
 
@@ -22,10 +22,24 @@ namespace StarlightRiver.Content.Items.BaseTypes
         private int boomTimer = 0;
 
         private static ParticleSystem.Update UpdateCursed => UpdateCursedBody;
-        public static ParticleSystem CursedSystem = new ParticleSystem("StarlightRiver/Assets/GUI/WhiteCircle", UpdateCursed);
+        public static ParticleSystem CursedSystem;
 
         private static ParticleSystem.Update UpdateShards => UpdateShardsBody;
-        public static ParticleSystem ShardsSystem = new ParticleSystem("StarlightRiver/Assets/GUI/charm", UpdateShards);
+
+        public static ParticleSystem ShardsSystem;
+
+        public float Priority => 1f;
+        public void Load()
+        {
+            CursedSystem = new ParticleSystem("StarlightRiver/Assets/GUI/WhiteCircle", UpdateCursed);
+            ShardsSystem = new ParticleSystem("StarlightRiver/Assets/GUI/charm", UpdateShards);
+        }
+
+        public void Unload()
+        {
+            CursedSystem = null;
+            ShardsSystem = null;
+        }
 
         protected CursedAccessory(Texture2D glow) : base("Unnamed Cursed Accessory", "You forgot to give this a display name dingus!")
         {
@@ -201,5 +215,5 @@ namespace StarlightRiver.Content.Items.BaseTypes
 
 			return base.PreDrawTooltipLine(line, ref yOffset);
 		}
-	}
+    }
 }

--- a/Content/Items/Misc/Weapons.TwistSword.cs
+++ b/Content/Items/Misc/Weapons.TwistSword.cs
@@ -184,8 +184,6 @@ namespace StarlightRiver.Content.Items.Misc
         private List<Vector2> cache;
         private Trail trail;
 
-        private bool justHit = false; //for mp sync
-
         public override string Texture => AssetDirectory.MiscItem + Name;
 
         public override void SetDefaults()

--- a/Content/Items/Moonstone/Armors.Datsuzei.cs
+++ b/Content/Items/Moonstone/Armors.Datsuzei.cs
@@ -16,25 +16,40 @@ using static Terraria.ModLoader.ModContent;
 
 namespace StarlightRiver.Content.Items.Moonstone
 {
-    public class Datsuzei : InworldItem
+    public class Datsuzei : InworldItem, ILoadable
     {
         public static int activationTimer = 0; //static since this is clientside only and there really shouldnt ever be more than one of these in that context
         public int comboState = 0;
 
-        public static ParticleSystem sparkles = new ParticleSystem(AssetDirectory.Dust + "Aurora", updateSparkles);
+        public static ParticleSystem sparkles;
 
         public override string Texture => AssetDirectory.MoonstoneItem + Name;
 
         public override bool VisibleInUI => false;
 
-		public override bool Autoload(ref string name)
+        public float Priority => 1f;
+
+        public override bool Autoload(ref string name)
 		{
-            StarlightPlayer.PostUpdateEvent += PlayerFrame;
-            On.Terraria.Main.DrawInterface_30_Hotbar += OverrideHotbar;
             return true;
 		}
 
-		public override void SetStaticDefaults()
+        public void Load()
+        {
+            StarlightPlayer.PostUpdateEvent += PlayerFrame;
+            On.Terraria.Main.DrawInterface_30_Hotbar += OverrideHotbar;
+            activationTimer = 0;
+            sparkles = new ParticleSystem(AssetDirectory.Dust + "Aurora", updateSparkles);
+    }
+
+        public void Unload()
+        {
+            StarlightPlayer.PostUpdateEvent -= PlayerFrame;
+            On.Terraria.Main.DrawInterface_30_Hotbar -= OverrideHotbar;
+            sparkles = null;
+        }
+
+        public override void SetStaticDefaults()
 		{
             DisplayName.SetDefault("Datsuzei");
             Tooltip.SetDefault("Unleash the moon");
@@ -258,7 +273,7 @@ namespace StarlightRiver.Content.Items.Moonstone
 		{
             tooltips[0].overrideColor = new Color(100, 255, 255);
 		}
-	}
+    }
 
 	public class DatsuzeiProjectile : ModProjectile, IDrawPrimitive
     {

--- a/Content/Items/Moonstone/Armors.MoonstoneArmor.cs
+++ b/Content/Items/Moonstone/Armors.MoonstoneArmor.cs
@@ -237,7 +237,7 @@ namespace StarlightRiver.Content.Items.Moonstone
                 if (player.mount.Active)
                     samplerState = Main.MountedSamplerState;
 
-                Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, samplerState, DepthStencilState.None, Main.instance.Rasterizer, null, Main.Transform);
+                Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, samplerState, DepthStencilState.None, Main.instance.Rasterizer, null, Main.GameViewMatrix.TransformationMatrix);
             }
         }
 

--- a/Content/Items/SteampunkSet/Weapons.Buzzsaw.cs
+++ b/Content/Items/SteampunkSet/Weapons.Buzzsaw.cs
@@ -345,12 +345,13 @@ namespace StarlightRiver.Content.Items.SteampunkSet
 
         public override void AI()
         {
-            if (justLaunched)
+            if (justLaunched && Main.myPlayer == projectile.owner)
             {
                 int proj = Projectile.NewProjectile(projectile.Center, Vector2.Zero, ModContent.ProjectileType<PhantomBuzzsaw>(), projectile.damage, projectile.knockBack, projectile.owner);
                 ((PhantomBuzzsaw)Main.projectile[proj].modProjectile).parent = projectile;
+                justLaunched = false;
             }
-                
+
             projectile.frameCounter += 1;
             projectile.frame = (projectile.frameCounter / 5) % 2;
             rotationCounter += 0.6f;
@@ -437,7 +438,7 @@ namespace StarlightRiver.Content.Items.SteampunkSet
                 projectile.active = false;
                 return;
             }
-                
+
 
             if (Main.myPlayer != projectile.owner)
                 findIfHit();
@@ -450,8 +451,6 @@ namespace StarlightRiver.Content.Items.SteampunkSet
 
         public override void OnHitNPC(NPC target, int damage, float knockback, bool crit)
         {
-
-            ((BuzzsawProj2)parent.modProjectile).hitGore(target);
 
             if (Main.myPlayer == projectile.owner)
             {
@@ -473,11 +472,12 @@ namespace StarlightRiver.Content.Items.SteampunkSet
 
             if (parent.modProjectile is BuzzsawProj2 modProj)
             {
+                modProj.hitGore(target);
                 modProj.pauseTimer = 16;
                 modProj.justHit = true;
             }
 
-            
+
         }
     }
 

--- a/Core/ParticleSystem.cs
+++ b/Core/ParticleSystem.cs
@@ -46,7 +46,6 @@ namespace StarlightRiver.Core
                     if (particle.Timer <= 0)
                     {
                         Particles.Remove(particle);
-                        Particles[k] = null;
                     }
                 }
         }

--- a/Core/StarlightPlayer.cs
+++ b/Core/StarlightPlayer.cs
@@ -312,8 +312,8 @@ namespace StarlightRiver.Core
 
 		public override void PlayerConnect(Player player)
         {
-            AbilityProgress packet = new AbilityProgress(this.player.whoAmI, this.player.GetHandler());
-            packet.Send();
+            AbilityProgress packet = new AbilityProgress(Main.myPlayer, Main.LocalPlayer.GetHandler());
+            packet.Send(runLocally: false);
         }
 
         public override float UseTimeMultiplier(Item item) => itemSpeed;

--- a/Helpers/LightingBuffer.cs
+++ b/Helpers/LightingBuffer.cs
@@ -11,14 +11,14 @@ namespace StarlightRiver.Helpers
 	public class LightingBuffer
     {
         const int PADDING = 20;
-        static readonly float factor = Main.screenHeight / (float)Main.screenWidth;
+        static float factor => Main.screenHeight / (float)Main.screenWidth;
 
         public static bool GettingColors = false;
 
-        public static VertexBuffer lightingQuadBuffer = new VertexBuffer(Main.instance.GraphicsDevice, typeof(VertexPositionColorTexture), 6, BufferUsage.WriteOnly);
+        public VertexBuffer lightingQuadBuffer;
 
-        public RenderTarget2D ScreenLightingTexture = new RenderTarget2D(Main.instance.GraphicsDevice, Main.screenWidth, Main.screenHeight, false, SurfaceFormat.Color, DepthFormat.None, 0, RenderTargetUsage.PreserveContents);
-        public RenderTarget2D TileLightingTexture = new RenderTarget2D(Main.instance.GraphicsDevice, XMax, YMax, false, SurfaceFormat.Color, DepthFormat.None, 0, RenderTargetUsage.PreserveContents);
+        public RenderTarget2D ScreenLightingTexture;
+        public RenderTarget2D TileLightingTexture;
         public RenderTarget2D TileLightingTempTexture;
         public Vector2 TileLightingCenter;
 
@@ -29,8 +29,10 @@ namespace StarlightRiver.Helpers
 
         private GraphicsConfig config => ModContent.GetInstance<GraphicsConfig>();
 
-        public static void SetupLightingQuadBuffer()
+        private void SetupLightingQuadBuffer()
         {
+            lightingQuadBuffer = new VertexBuffer(Main.instance.GraphicsDevice, typeof(VertexPositionColorTexture), 6, BufferUsage.WriteOnly);
+
             VertexPositionColorTexture[] verticies = new VertexPositionColorTexture[6];
 
             verticies[0] = new VertexPositionColorTexture(new Vector3(-1, -1, 0), Color.White, new Vector2(0, 1));
@@ -42,6 +44,11 @@ namespace StarlightRiver.Helpers
             verticies[5] = new VertexPositionColorTexture(new Vector3(1, 1, 0), Color.White, new Vector2(1, 0));
 
             lightingQuadBuffer.SetData(verticies);
+        }
+
+        public LightingBuffer()
+        {
+            ResizeBuffers(Main.screenWidth, Main.screenHeight);
         }
 
         public void ResizeBuffers(int width, int height)
@@ -60,12 +67,14 @@ namespace StarlightRiver.Helpers
             Color[] tileLightingBuffer = new Color[TileLightingTexture.Width * TileLightingTexture.Height];
 
             for (int x = 0; x < TileLightingTexture.Width; x++)
+            {
                 for (int y = 0; y < TileLightingTexture.Height; y++)
                 {
                     int index = y * TileLightingTexture.Width + x;
-                    if (tileLightingBuffer.Length > index) tileLightingBuffer[index] = Lighting.GetColor((int)start.X / 16 + x, (int)start.Y / 16 + y);
+                    if (tileLightingBuffer.Length > index) 
+                        tileLightingBuffer[index] = Lighting.GetColor((int)start.X / 16 + x, (int)start.Y / 16 + y);
                 }
-
+            }
             TileLightingTexture.SetData(tileLightingBuffer);
             TileLightingCenter = start;
             GettingColors = false;
@@ -114,14 +123,18 @@ namespace StarlightRiver.Helpers
             if (Main.dedServ) 
                 return;
 
+            if (lightingQuadBuffer == null)
+                SetupLightingQuadBuffer(); //a bit hacky, but if we do this on load we can end up with black textures for full screen users, and full screen does not fire set display mode events
+
             Effect upscaleEffect = Filters.Scene["LightShader"].GetShader().Shader;
 
             GraphicsDevice graphics = Main.instance.GraphicsDevice;
-
+            
             graphics.SetVertexBuffer(lightingQuadBuffer);
             graphics.RasterizerState = new RasterizerState() { CullMode = CullMode.None };
 
             Vector2 offset = (Main.screenPosition - TileLightingCenter) / new Vector2(Main.screenWidth, Main.screenHeight);
+            
 
             upscaleEffect.Parameters["screenSize"].SetValue(new Vector2(Main.screenWidth, Main.screenHeight));
             upscaleEffect.Parameters["fullBufferSize"].SetValue(TileLightingTexture.Size() * 16);

--- a/Helpers/LightingBuffer.cs
+++ b/Helpers/LightingBuffer.cs
@@ -4,8 +4,6 @@ using StarlightRiver.Configs;
 using Terraria;
 using Terraria.Graphics.Effects;
 using Terraria.ModLoader;
-using StarlightRiver.Configs;
-using StarlightRiver.Physics;
 using static StarlightRiver.Helpers.DrawHelper;
 
 namespace StarlightRiver.Helpers


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
This is to fix several bugs discovered during the larger multiplayer test.

fix for no build allowing hammering blocks
fix for buzzsaw unsafely typecasting
Cieros has added check to make sure player is not dead when selecting a random target
Cieros cutscenes modified to run for all players for logic and split out the clientside only portions to those inside arena
fix for twist sword crash and particle system crash after reloading mod
fix for fresh characters getting unlocked abilities after someone else obtains the ability in multiplayer + packet optimizations on world load for sharing unlock statuses
fix for black textures when in full screen


### What are the implementation specifics of this change? Are there any consequences?
generally should have no effects on gameplay ouside of fixing the bugs. cutscene fixes were implemented with doing a sort of smear of the globaltime when recieving a packet so a few ticks of rewinding can occur, maybe rethink this in the future if it causes problems in laggy scenarios