### PR TITLE
More mp fixes

### DIFF
--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.Attacks.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.Attacks.cs
@@ -19,6 +19,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
         {
             AttackTimer = 0;
             SetFrameY(0);
+            npc.netUpdate = true;
         }
 
         private void RandomizeTarget()
@@ -73,12 +74,13 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
             {
                 startPos = npc.Center;
 
+                while (crystalLocations.Count < 4)
+                {
+                    BuildCrystalLocations();
+                }
+
                 if (Main.netMode != NetmodeID.MultiplayerClient)
                 {
-                    while (crystalLocations.Count < 4)
-                    {
-                        BuildCrystalLocations();
-                    }
 
                     List<Vector2> possibleLocations = new List<Vector2>(crystalLocations);
                     possibleLocations.ForEach(n => n += new Vector2(0, -48));
@@ -248,6 +250,11 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
         private void CrystalSmash()
         {
+            while (crystalLocations.Count < 4)
+            {
+                BuildCrystalLocations();
+            }
+
             //boss during the attack
             if (AttackTimer == 1)
                 endPos = npc.Center; //set the ending point to the center of the arena so we can come back later
@@ -276,7 +283,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
             {
                 NPC crystal = crystals[k];
                 VitricBossCrystal crystalModNPC = crystal.modNPC as VitricBossCrystal;
-                if (AttackTimer == lockSpeed + k * lockSpeed) //set motion points correctly
+                if (AttackTimer == lockSpeed + k * lockSpeed && Main.netMode != NetmodeID.MultiplayerClient) //set motion points correctly
                 {
                     RandomizeTarget(); //pick a random target to smash a crystal down
 
@@ -285,8 +292,9 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     crystalModNPC.StartPos = crystal.Center;
                     crystalModNPC.TargetPos = new Vector2(player.Center.X + player.velocity.X * 50, player.Center.Y - 250); //endpoint is above the player
                     crystalModNPC.TargetPos.X = MathHelper.Clamp(crystalModNPC.TargetPos.X, homePos.X - 800, homePos.X + 800);
+                    crystal.netUpdate = true;
                 }
-             
+
                 if (AttackTimer >= lockSpeed + k * lockSpeed && AttackTimer <= lockSpeed + (k + 1) * lockSpeed) //move the crystal there
                     crystal.Center = Vector2.SmoothStep(crystalModNPC.StartPos, crystalModNPC.TargetPos, (AttackTimer - (lockSpeed + k * lockSpeed)) / lockSpeed);
 
@@ -298,7 +306,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     crystalModNPC.TargetPos = player.Center;
                 }
             }
-
+            
             //ending the attack
             if (AttackTimer > 120 + lockSpeed * 4) ResetAttack();
         }
@@ -398,7 +406,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
                         startPos = npc.Center; 
                         endPos = crystalLocations[k] + new Vector2(0, -30); 
-                        RandomizeTarget(); 
+                        RandomizeTarget();
                     } //set positions and randomize the target
 
                     if (timer < 60)
@@ -523,7 +531,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 {
                     int timer = (int)AttackTimer - (140 + k * 140); //0 to 240, grabs the relative timer for ease of writing code
 
-                    if (timer == 0)
+                    if (timer == 0 && Main.netMode != NetmodeID.MultiplayerClient)
                     {
                         startPos = npc.Center;
                         endPos = crystalLocations[bossRand.Next(crystalLocations.Count)] + new Vector2(0, -30);

--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.Cutscenes.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.Cutscenes.cs
@@ -30,7 +30,8 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
             //if the globaltimer gets fastforwarded from recieving a packet (generally rare to skip)
             //we want to make sure we still perform all the specific timer increments so things aren't lost like assigning the music or other effects
             //possible to reverse a few ticks aswell but thats generally safe and the worst that happens is doubling up on screenshake since a few frames of offset duplicate sound effects is indistinguishable
-            return (GlobalTimer == time || (justRecievedPacket && prevTickGlobalTimer < time && GlobalTimer > time));
+            //limit the tick difference cause otherwise may end up with a super reverse of the whole cutscene when some weirdness happens, if the lag is extreme enough, things may just break
+            return (GlobalTimer == time || (justRecievedPacket && prevTickGlobalTimer < time && GlobalTimer > time && Math.Abs(prevTickGlobalTimer - GlobalTimer) < 15));
         }
         private void SpawnAnimation() //The animation which plays when the boss is spawning
         {
@@ -39,7 +40,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             if (checkSpecificTime(2))
             {
-                npc.friendly = true; //so he wont kill you during the animation
                 RandomizeTarget(); //pick a random target so the eyes will follow them
                 startPos = npc.Center;
 
@@ -232,7 +232,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                 SetFrameY(0);
 
                 npc.dontTakeDamage = false; //make him vulnerable
-                npc.friendly = false; //and hurt when touched
                 homePos = npc.Center; //set the NPCs home so it can return here after attacks
                 int index = NPC.NewNPC((int)npc.Center.X, (int)npc.Center.Y, NPCType<ArenaBottom>());
                 (Main.npc[index].modNPC as ArenaBottom).Parent = this;
@@ -264,7 +263,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
             if (checkSpecificTime(140))
             {
                 SetFrameX(1);
-                npc.friendly = true; //so we wont get contact damage
 
                 if (IsInsideArena())
                 {

--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
@@ -139,7 +139,11 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
         {
             if (Phase == (int)AIStates.Dying && GlobalTimer >= 659)
             {
-                foreach (NPC npc in Main.npc.Where(n => n.modNPC is VitricBackdropLeft || n.modNPC is VitricBossPlatformUp)) npc.active = false; //reset arena                
+                if (Main.netMode != NetmodeID.MultiplayerClient)
+                {
+                    foreach (NPC npc in Main.npc.Where(n => n.modNPC is VitricBackdropLeft || n.modNPC is VitricBossPlatformUp))
+                        npc.active = false; //reset arena      
+                }
                 return true;
             }
 
@@ -600,10 +604,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     Vignette.visible = true;
 
                     if (GlobalTimer == 60)
-                    {
                         npc.dontTakeDamage = false; //damagable again
-                        npc.friendly = false;
-                    }
 
                     if (AttackTimer == 1) //switching out attacks
                     {

--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.cs
@@ -657,6 +657,17 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             body?.UpdateBody(); //update the physics on the body, last, so it can override framing
 
+            if (Main.netMode == NetmodeID.Server)
+            {
+                //instantly switch targets if no longer valid
+                Player target = Main.player[npc.target];
+                if (!target.active || target.dead || !arena.Contains(target.Center.ToPoint()))
+                {
+                    RandomizeTarget();
+                    npc.netUpdate = true;
+                }
+            }
+
             if (Main.netMode == NetmodeID.Server && (Phase != prevPhase || AttackPhase != prevAttackPhase))
             {
                 prevPhase = Phase;
@@ -729,7 +740,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
             writer.Write(npc.defense);
 
             writer.Write(npc.target);
-
         }
 
         public override void ReceiveExtraAI(System.IO.BinaryReader reader)

--- a/Content/Bosses/VitricBoss/NPCs.VitricBossCrystal.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBossCrystal.cs
@@ -13,6 +13,7 @@ using static Terraria.ModLoader.ModContent;
 using StarlightRiver.Packets;
 using Terraria.ID;
 using System.IO;
+using StarlightRiver.Content.NPCs.BaseTypes;
 
 namespace StarlightRiver.Content.Bosses.VitricBoss
 {
@@ -323,6 +324,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     }
 
                     if (npc.Center.Y > TargetPos.Y)
+                    {
                         foreach (Vector2 point in Parent.crystalLocations) //Better than cycling througn Main.npc, still probably a better way to do this
                         {
                             Rectangle hitbox = new Rectangle((int)point.X - 110, (int)point.Y + 48, 220, 16); //grabs the platform hitbox
@@ -332,6 +334,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                                 Impact();
                             }
                         }
+                    }
 
                     Tile tile = Framing.GetTileSafely((int)npc.Center.X / 16, (int)(npc.Center.Y + 24) / 16);
 
@@ -378,8 +381,6 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             for (int k = 0; k < 40; k++)
                 Dust.NewDustPerfect(npc.Center, DustType<Dusts.Stamina>(), Vector2.One.RotatedByRandom(6.28f) * Main.rand.NextFloat(7));
-
-            npc.netUpdate = true;
         }
 
         private void ResetTimers()

--- a/Content/Bosses/VitricBoss/NPCs.VitricBossCrystal.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBossCrystal.cs
@@ -170,9 +170,10 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
                     if (Abilities.AbilityHelper.CheckDash(player, npc.Hitbox))
                     {
-                        Main.LocalPlayer.GetModPlayer<StarlightPlayer>().Shake += 20;
+                        if (Parent.arena.Contains(Main.LocalPlayer.Center.ToPoint()))
+                            Main.LocalPlayer.GetModPlayer<StarlightPlayer>().Shake += 20;
 
-                        Main.PlaySound(Terraria.ID.SoundID.DD2_WitherBeastCrystalImpact);
+                        Main.PlaySound(Terraria.ID.SoundID.DD2_WitherBeastCrystalImpact, (int)npc.Center.X, (int)npc.Center.Y);
                         Main.PlaySound(Terraria.ID.SoundID.Item70.SoundId, (int)npc.Center.X, (int)npc.Center.Y, Terraria.ID.SoundID.Item70.Style, 2, -0.5f);
 
                         player.GetModPlayer<Abilities.AbilityHandler>().ActiveAbility?.Deactivate();
@@ -190,12 +191,14 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                         for (int k = 0; k < 5; k++) 
                             Gore.NewGore(Parent.npc.Center, Vector2.One.RotatedBy(k / 4f * 6.28f) * 4, mod.GetGoreSlot("Gores/ShieldGore"));
 
+                        
                         if(Main.netMode == Terraria.ID.NetmodeID.MultiplayerClient && Main.myPlayer == player.whoAmI)
 						{
-                            var packet = new CeirosCrystal(Main.myPlayer, npc.whoAmI, Parent.npc.whoAmI);
-                            packet.Send();
+                            var packet = new CeirosCrystal(Main.myPlayer, npc.whoAmI, Parent.npc.whoAmI, player.velocity);
+                            packet.Send(runLocally: false);
                             return;
 						}
+                        
 
                         state = 1; //It's all broken and on the floor!
                         phase = 0; //go back to doing nothing

--- a/Content/CustomHooks/Visuals.PlayerTarget.cs
+++ b/Content/CustomHooks/Visuals.PlayerTarget.cs
@@ -203,7 +203,7 @@ namespace StarlightRiver.Content.CustomHooks
                     Main.player[i].MountedCenter = oldMountedCenter - oldPos + positionOffset;
                     Main.player[i].heldProj = -1;
                     Main.screenPosition = Vector2.Zero;
-                    playerDrawMethod?.Invoke(Main.instance, new object[] { Main.player[i], Main.player[i].position, 0f, Vector2.Zero, 0f });
+                    playerDrawMethod?.Invoke(Main.instance, new object[] { Main.player[i], Main.player[i].position, Main.player[i].fullRotation, Main.player[i].fullRotationOrigin, 0f });
 
                     Main.player[i].position = oldPos;
                     Main.player[i].Center = oldCenter;

--- a/Content/Items/Breacher/Weapons.Scrapshot.cs
+++ b/Content/Items/Breacher/Weapons.Scrapshot.cs
@@ -344,7 +344,7 @@ namespace StarlightRiver.Content.Items.Breacher
 
             if (struck)
             {
-                player.fullRotation = (projectile.timeLeft / 20f) * 3.14f * player.direction;
+                player.fullRotation += (projectile.timeLeft / 20f) * 3.14f * player.direction;
                 player.fullRotationOrigin = player.Size / 2;
                 player.velocity *= 0.95f;
             }

--- a/Content/Items/Vitric/Weapons.VitricHook.cs
+++ b/Content/Items/Vitric/Weapons.VitricHook.cs
@@ -147,7 +147,7 @@ namespace StarlightRiver.Content.Items.Vitric
 
             if(struck)
             {
-                player.fullRotation = (projectile.timeLeft / 20f) * 3.14f * player.direction;
+                player.fullRotation += (projectile.timeLeft / 20f) * 3.14f * player.direction;
                 player.fullRotationOrigin = player.Size / 2;
                 player.velocity *= 0.95f;
             }

--- a/Content/NPCs/BaseTypes/GravityOrbTest.cs
+++ b/Content/NPCs/BaseTypes/GravityOrbTest.cs
@@ -85,11 +85,6 @@ namespace StarlightRiver.Content.NPCs.BaseTypes
                 drawInfo.drawPlayer.fullRotationOrigin = drawInfo.drawPlayer.Size / 2;
                 drawInfo.drawPlayer.fullRotation = realAngle + (float)Math.PI * 0.5f * angleTimer / 59f;
             }
-            else
-            {
-                drawInfo.drawPlayer.fullRotationOrigin = Vector2.Zero;
-                drawInfo.drawPlayer.fullRotation = 0;
-            }
         }
 
         public override void PostUpdate()

--- a/Content/Packets/CeirosCrystalPacket.cs
+++ b/Content/Packets/CeirosCrystalPacket.cs
@@ -2,10 +2,14 @@
 using NetEasy;
 using StarlightRiver.Content.Abilities;
 using StarlightRiver.Content.Bosses.VitricBoss;
+using StarlightRiver.Content.Dusts;
+using StarlightRiver.Core;
 using System;
 using System.Linq;
 using Terraria;
+using Terraria.ID;
 using static StarlightRiver.Content.Bosses.VitricBoss.VitricBoss;
+using static Terraria.ModLoader.ModContent;
 
 namespace StarlightRiver.Packets
 {
@@ -15,22 +19,55 @@ namespace StarlightRiver.Packets
         private readonly int fromWho;
         private readonly int whosBreaking;
         private readonly int whosTheBoss;
+        private readonly Vector2 newPlayerVelocity; //we send velocity instead of multiplying since we don't want a race condition with a player update packet to end up wildly changing player velocity
 
-        public CeirosCrystal(int fromWho, int whosBreaking, int whosTheBoss)
+        public CeirosCrystal(int fromWho, int whosBreaking, int whosTheBoss, Vector2 newPlayerVelocity)
         {
             this.fromWho = fromWho;
             this.whosBreaking = whosBreaking;
             this.whosTheBoss = whosTheBoss;
+            this.newPlayerVelocity = newPlayerVelocity;
         }
 
         protected override void Receive()
         {
-            if (Main.netMode == Terraria.ID.NetmodeID.Server)
-            {
-                var crystal = Main.npc[whosBreaking];
-                var crystalMod = crystal.modNPC as VitricBossCrystal;
+            //other clients only need to perform visuals and the player movement, npc updates will come from different packets
 
-                var Parent = Main.npc[whosTheBoss].modNPC as VitricBoss;
+            NPC crystal = Main.npc[whosBreaking];
+            VitricBoss Parent = Main.npc[whosTheBoss].modNPC as VitricBoss;
+            Player player = Main.player[fromWho];
+
+            //turn off the ability of the player who collided and deactivate it
+            player.GetModPlayer<AbilityHandler>().ActiveAbility?.Deactivate();
+            player.velocity = newPlayerVelocity;
+
+            if (Main.netMode == NetmodeID.MultiplayerClient)
+            {
+                //visuals and sounds for other players
+
+                if (Parent.arena.Contains(Main.LocalPlayer.Center.ToPoint()))
+                    Main.LocalPlayer.GetModPlayer<StarlightPlayer>().Shake += 10;
+
+                Main.PlaySound(SoundID.DD2_WitherBeastCrystalImpact, (int)crystal.Center.X, (int)crystal.Center.Y);
+                Main.PlaySound(SoundID.Item70.SoundId, (int)crystal.Center.X, (int)crystal.Center.Y, SoundID.Item70.Style, 2, -0.5f);
+
+                for (int k = 0; k < 20; k++)
+                {
+                    Dust.NewDustPerfect(crystal.Center, DustType<GlassGravity>(), Vector2.One.RotatedByRandom(6.28f) * Main.rand.NextFloat(8), 0, default, 2.2f); //Crystal
+                    Dust.NewDustPerfect(crystal.Center, DustType<Glow>(), Vector2.One.RotatedByRandom(6.28f) * Main.rand.NextFloat(4), 0, new Color(150, 230, 255), 0.8f); //Crystal
+                }
+
+                for (int k = 0; k < 40; k++)
+                    Dust.NewDustPerfect(Parent.npc.Center, DustType<GlassGravity>(), Vector2.One.RotatedByRandom(6.28f) * Main.rand.NextFloat(6), 0, default, 2.6f); //Boss
+
+                for (int k = 0; k < 5; k++)
+                    Gore.NewGore(Parent.npc.Center, Vector2.One.RotatedBy(k / 4f * 6.28f) * 4, mod.GetGoreSlot("Gores/ShieldGore"));
+
+            }
+            else if (Main.netMode == NetmodeID.Server)
+            {
+                //logic for phase updates
+                var crystalMod = crystal.modNPC as VitricBossCrystal;
 
                 crystalMod.state = 1; //It's all broken and on the floor!
                 crystalMod.phase = 0; //go back to doing nothing
@@ -47,6 +84,8 @@ namespace StarlightRiver.Packets
                     npc.friendly = false; //damaging again
                     npc.netUpdate = true;
                 }
+
+                Send(-1, fromWho, false);
             }
         }
     }

--- a/Core/StarlightPlayer.cs
+++ b/Core/StarlightPlayer.cs
@@ -109,6 +109,8 @@ namespace StarlightRiver.Core
 
             trueInvisible = false;
 
+            player.fullRotation = 0;
+
             shouldSendHitPacket = false;
 
             if (Shake > 120 * ModContent.GetInstance<Configs.GraphicsConfig>().ScreenshakeMult)


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
This is to fix issues from the previous demo build.

fixes players getting stuck rotated after using scraphook or ripshatter
modifed player render target to use full rotation
improvements to Cieros and crystal movement sync
better visual effect sync of smashing crystals for the health gates
Cieros instantly retargets when targetted player dies
fix for Cieros getting invulnerable rarely in mp from being set to friendly


### What are the implementation specifics of this change? Are there any consequences?
only notable consequence is that player.fullrotation is being reset in reset effects from now on 