### PR TITLE
hooks give jump back on moving platforms

### DIFF
--- a/Content/Bosses/VitricBoss/NPCs.ArenaBacks.cs
+++ b/Content/Bosses/VitricBoss/NPCs.ArenaBacks.cs
@@ -185,7 +185,7 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
 
             }
 
-            if (prevState != State && Main.netMode == NetmodeID.Server)
+            if ((prevState != State || (State == 3 && Timer % 60 == 0)) && Main.netMode == NetmodeID.Server)
             {
                 npc.netUpdate = true;
                 prevState = State;

--- a/Content/CustomHooks/Mechanics.MovingPlatforms.cs
+++ b/Content/CustomHooks/Mechanics.MovingPlatforms.cs
@@ -43,8 +43,23 @@ namespace StarlightRiver.Content.CustomHooks
 
                 Rectangle playerRect = new Rectangle((int)self.position.X, (int)self.position.Y + (self.height), self.width, 1);
                 Rectangle npcRect = new Rectangle((int)npc.position.X, (int)npc.position.Y, npc.width, 8 + (self.velocity.Y > 0 ? (int)self.velocity.Y : 0));
-                
-                if (playerRect.Intersects(npcRect) && self.position.Y <= npc.position.Y)
+
+                if (self.grapCount == 1 && npc.velocity.Y != 0)
+                {
+                    //if the player is using a single grappling hook we can check if they are colliding with it and its embedded in the moving platform, while its changing Y position so we can give the player their jump back
+                    foreach (int eachGrappleIndex in self.grappling)
+                    {
+                        Projectile grappleHookProj = Main.projectile[eachGrappleIndex];
+                        if (grappleHookProj.active && npc.Hitbox.Intersects(grappleHookProj.Hitbox) && self.Hitbox.Intersects(grappleHookProj.Hitbox))
+                        {
+                            self.position = grappleHookProj.position + new Vector2(grappleHookProj.width / 2 - self.width / 2, grappleHookProj.height / 2 - self.height / 2);
+                            self.position += npc.velocity;
+                            self.velocity.Y = 0;
+                            self.jump = 0;
+                            self.fallStart = (int)(self.position.Y / 16f);
+                        }
+                    }
+                } else if (playerRect.Intersects(npcRect) && self.position.Y <= npc.position.Y)
                 {
                     if (!self.justJumped && self.velocity.Y >= 0)
                     {


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
this enables hooks to give players their jump again when they stop at the hook while the platform is moving. previously if the platform was moving hooking to it would not give the player a jump. this is to bring it more in line with how platforms are expected to function

### What are the implementation specifics of this change? Are there any consequences?
this is done through checking if the player has a single hook active and if so, checking if it and the player are all intersecting hit boxes with the moving platform and if so, sets the players position to the correct hook position directly so they will be able to zero out their Y velocity for the frame and get their jump back. Maybe a rework into an advanced version in the future that checks if the player has approximately reached the center of multiple hooks that are on moving platforms to give jump back in that situation too.