### PR TITLE
minor mp fixes.

### DIFF
--- a/Content/Bosses/VitricBoss/NPCs.VitricBoss.Cutscenes.cs
+++ b/Content/Bosses/VitricBoss/NPCs.VitricBoss.Cutscenes.cs
@@ -229,12 +229,16 @@ namespace StarlightRiver.Content.Bosses.VitricBoss
                     BootlegHealthbar.visible = true;
                 }
 
+                if (Main.netMode != NetmodeID.MultiplayerClient)
+                {
+                    int index = NPC.NewNPC((int)npc.Center.X, (int)npc.Center.Y, NPCType<ArenaBottom>());
+                    (Main.npc[index].modNPC as ArenaBottom).Parent = this;
+                }
+
                 SetFrameY(0);
 
                 npc.dontTakeDamage = false; //make him vulnerable
                 homePos = npc.Center; //set the NPCs home so it can return here after attacks
-                int index = NPC.NewNPC((int)npc.Center.X, (int)npc.Center.Y, NPCType<ArenaBottom>());
-                (Main.npc[index].modNPC as ArenaBottom).Parent = this;
                 ChangePhase(AIStates.FirstPhase, true);
                 ResetAttack();
                 npc.netUpdate = true;

--- a/Content/Tiles/Vitric/VitricBossAltar.cs
+++ b/Content/Tiles/Vitric/VitricBossAltar.cs
@@ -216,6 +216,7 @@ namespace StarlightRiver.Content.Tiles.Vitric
                  )))
                 {
                     npc.active = false;
+                    npc.netUpdate = true;
                 }
 
                 Vector2 center = projectile.Center + new Vector2(0, 60);

--- a/Content/Tiles/Vitric/VitricOre.cs
+++ b/Content/Tiles/Vitric/VitricOre.cs
@@ -93,8 +93,13 @@ namespace StarlightRiver.Content.Tiles.Vitric
         {
             if (AbilityHelper.CheckDash(player, projectile.Hitbox))
             {
-                WorldGen.KillTile((int)(projectile.position.X / 16f), (int)(projectile.position.Y / 16f));
-                NetMessage.SendTileRange(player.whoAmI, (int)(projectile.position.X / 16f), (int)(projectile.position.Y / 16f), 2, 3, TileChangeType.None);
+                if (Main.myPlayer == player.whoAmI)
+                {
+                    WorldGen.KillTile((int)(projectile.position.X / 16f), (int)(projectile.position.Y / 16f));
+                    NetMessage.SendTileRange(player.whoAmI, (int)(projectile.position.X / 16f), (int)(projectile.position.Y / 16f), 2, 3, TileChangeType.None);
+                } 
+                else
+                    Main.PlaySound(SoundID.Shatter, projectile.Center);
 
                 for (int k = 0; k <= 10; k++)
                 {
@@ -123,8 +128,13 @@ namespace StarlightRiver.Content.Tiles.Vitric
         {
             if (AbilityHelper.CheckDash(player, projectile.Hitbox))
             {
-                WorldGen.KillTile((int)(projectile.position.X / 16f), (int)(projectile.position.Y / 16f));
-                NetMessage.SendTileRange(player.whoAmI, (int)(projectile.position.X / 16f), (int)(projectile.position.Y / 16f), 2, 2, TileChangeType.None);
+                if (Main.myPlayer == player.whoAmI)
+                {
+                    WorldGen.KillTile((int)(projectile.position.X / 16f), (int)(projectile.position.Y / 16f));
+                    NetMessage.SendTileRange(player.whoAmI, (int)(projectile.position.X / 16f), (int)(projectile.position.Y / 16f), 2, 2, TileChangeType.None);
+                }
+                else
+                    Main.PlaySound(SoundID.Shatter, projectile.Center);
 
                 for (int k = 0; k <= 10; k++)
                 {

--- a/Core/Dummy.cs
+++ b/Core/Dummy.cs
@@ -27,7 +27,7 @@ namespace StarlightRiver.Core
             Height = height;
         }
 
-        public virtual bool ValidTile(Tile tile) => tile is null || tile.type == ValidType; //the tile is null only where tiles are unloaded in multiplayer. We don't want to kill off dummies on unloaded tiles until tile is known because projectile is recieved MUCH farther than the tiles.
+        public virtual bool ValidTile(Tile tile) => tile is null || (tile.type == ValidType && tile.active()); //the tile is null only where tiles are unloaded in multiplayer. We don't want to kill off dummies on unloaded tiles until tile is known because projectile is recieved MUCH farther than the tiles.
 
         public override bool PreDraw(SpriteBatch spriteBatch, Color lightColor) => false;
 


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
this is to fix a few remaining mp bugs found for the demo
improved returning jump for downwards moving platforms
arena bottom no longer spawns client side -- fixes minor bug where the bottom could proc more than once
fixes to dummy deletion detection -- wtf relogic why is there an "active" field for tiles that only applies to mp when its sending packets for the tile changes anyway????
### What are the implementation specifics of this change? Are there any consequences?
should be no consequences to these changes