### PR TITLE
Bold intro text, to match the other template intro texts

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/minor-bug-report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ## Issue Description
-A thorough description of the problem, including:
+**A thorough description of the problem, including:**
     Expected behavior: [What was supposed to happen?]
     Actual behavior: [What did happen?]
     Mod list: [What mods you have loaded?]


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
minor-bug-report.md does not have the same bolded text in the beginning to introduce the template.
### What are the implementation specifics of this change? Are there any consequences?
This only makes the first text, the issue introductory text, underneath the header bold like the other texts underneath the header on their markdown issue files.
There are no consequences, as it is a very minor change.
![image](https://user-images.githubusercontent.com/70764728/168509269-a9b09ab6-24b7-49f6-8d95-634278287692.png)
![image](https://user-images.githubusercontent.com/70764728/168509275-bbdf82f2-4a2d-445c-8fc9-7aef096636f8.png)
