### PR TITLE
Accessory simulation

### DIFF
--- a/Content/Items/BaseTypes/SmartAccessory.cs
+++ b/Content/Items/BaseTypes/SmartAccessory.cs
@@ -1,45 +1,126 @@
-﻿using Terraria;
+﻿using On.Terraria.GameContent.Achievements;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Terraria;
 using Terraria.ModLoader;
 
 namespace StarlightRiver.Content.Items.BaseTypes
 {
 	public abstract class SmartAccessory : ModItem
     {
-        private readonly string ThisName;
-        private readonly string ThisTooltip;
+        /// <summary>
+        /// For use with simulated accessories, the accessory simulating this one is it's parent.
+        /// This is a list for if you are simulating the same accessory from multiple sources,
+        /// so it is only lost when all are unequipped and can persist if only one is.
+        ///  </summary>
+        public List<Item> parents = new List<Item>();
+        public bool isChild; //If the item should dissappear if all of its parents are gone
+
+        private readonly string name;
+        private readonly string tooltip;
+
+        /// <summary>
+        /// Override this and add the types of SmartAccessories you want this one to simulate. Note that simulated accessories are reset on unequip/reload, so you will need to save any persistent data on the parent accessory.
+        /// </summary>
+        public virtual List<int> ChildTypes => new List<int>();
 
         protected SmartAccessory(string name, string tooltip) : base()
         {
-            ThisName = name;
-            ThisTooltip = tooltip;
+            this.name = name;
+            this.tooltip = tooltip;
         }
 
-        public bool Equipped(Player Player)
+        /// <summary>
+        /// If this accessory is equipped in a normal slot on the given player or simulated by another accessory.
+        /// </summary>
+        /// <param name="Player">The player to check for the item on</param>
+        /// <returns>If the item is equipped or simulated.</returns>
+		public bool Equipped(Player Player)
         {
             for (int k = 3; k <= 7 + Player.extraAccessorySlots; k++)
                 if (Player.armor[k].type == Item.type)
                     return true;
 
+            var mp = Player.GetModPlayer<AccessorySimulationPlayer>();
+            if (mp.simulatedAccessories.Any(n => n.type == Item.type))
+                return true;
+
             return false;
         }
 
+        /// <summary>
+        /// Gets the instance of this accessory thats equipped in a player's normal slots or that is being simulated by other accessories.
+        /// </summary>
+        /// <param name="Player">The player to get the equipped instance from.</param>
+        /// <returns>The SmartAccessory instance if one is found, null if the item is not equipped or simulated.</returns>
         public SmartAccessory GetEquippedInstance(Player Player)
 		{
             for (int k = 3; k <= 7 + Player.extraAccessorySlots; k++)
+            {
                 if (Player.armor[k].type == Item.type)
                     return Player.armor[k].ModItem as SmartAccessory;
+            }
 
-            return null;
+            var mp = Player.GetModPlayer<AccessorySimulationPlayer>();
+            return mp.simulatedAccessories.FirstOrDefault(n => n.type == Item.type)?.ModItem as SmartAccessory;
         }
+
+        /// <summary>
+        /// Adds an item to be simulated.
+        /// </summary>
+        /// <param name="itemType"></param>
+        /// <param name="player"></param>
+        private void Simulate(int itemType, Player player)
+		{
+            var mp = player.GetModPlayer<AccessorySimulationPlayer>();
+
+            var existingSimulacrum = mp.simulatedAccessories.FirstOrDefault(n => n.type == itemType);
+            var simulacrumModItem = existingSimulacrum?.ModItem as SmartAccessory;
+
+            if (existingSimulacrum is null) //There isnt a simulation for this accessory yet, lets add one!
+			{
+                var item = new Item();
+                item.SetDefaults(itemType);
+
+                mp.simulatedAccessories.Add(item);
+                simulacrumModItem = item.ModItem as SmartAccessory;
+                simulacrumModItem.Equip(player, item);
+                simulacrumModItem.parents.Add(Item);
+                simulacrumModItem.isChild = true;
+                return;
+			}
+
+            if (!simulacrumModItem.parents.Contains(Item)) //Add this item to the parents if there is one being simulated already, but it isnt already parented to this
+                simulacrumModItem.parents.Add(Item);
+        }
+
+        public void Equip(Player player, Item item)
+		{
+            foreach (int type in ChildTypes)
+                Simulate(type, player);
+
+            OnEquip(player, item);
+		}
+
+        /// <summary>
+        /// Effects which happen when the accessory is equipped. Generally should be kept to things such as resetting data.
+        /// </summary>
+        /// <param name="player"></param>
+        /// <param name="item"></param>
+        /// <param name="context"></param>
+        public virtual void OnEquip(Player player, Item item) { }
 
         public virtual void SafeSetDefaults() { }
 
         public virtual void SafeUpdateEquip(Player Player) { }
 
+        public virtual bool SafeCanAccessoryBeEquippedWith(Item equipped, Item incoming, Player player) { return true; }
+
         public override void SetStaticDefaults()
         {
-            DisplayName.SetDefault(ThisName);
-            Tooltip.SetDefault(ThisTooltip);
+            DisplayName.SetDefault(name);
+            Tooltip.SetDefault(tooltip);
         }
 
         public sealed override void SetDefaults()
@@ -50,9 +131,86 @@ namespace StarlightRiver.Content.Items.BaseTypes
             Item.accessory = true;
         }
 
-        public sealed override void UpdateEquip(Player Player)
+        public sealed override void UpdateEquip(Player player)
         {
-            SafeUpdateEquip(Player);
+            if (isChild)
+            {               
+                var toRemove = new List<Item>(); //Removes unequipped accessories from parents
+
+                foreach (var item in parents)
+                {
+                    var modItem = item.ModItem as SmartAccessory;
+                    if (modItem is null || !modItem.Equipped(player))
+                        toRemove.Add(item);
+                }
+
+                toRemove.ForEach(n => parents.Remove(n));
+                toRemove.Clear();
+
+                if (parents.Count == 0) //Destroy this simulation if it has no viable parents
+                    Item.TurnToAir();
+            }
+
+            SafeUpdateEquip(player);
         }
-    }
+
+		public sealed override bool CanAccessoryBeEquippedWith(Item equippedItem, Item incomingItem, Player player)
+		{
+			if(equippedItem.ModItem is SmartAccessory && incomingItem.ModItem is SmartAccessory)
+			{
+                var equipped = equippedItem.ModItem as SmartAccessory;
+                var incoming = incomingItem.ModItem as SmartAccessory;
+
+                if (equipped.ChildTypes.Contains(incoming.Type) || incoming.ChildTypes.Contains(equipped.Type)) //Prevents equipping up or down a simulation chain
+                    return false;
+
+                /*var mp = player.GetModPlayer<AccessorySimulationPlayer>();
+
+                if (mp.simulatedAccessories.Any(n => n.type == incomingItem.type))
+                    return false;*/
+            }
+
+            return SafeCanAccessoryBeEquippedWith(equippedItem, incomingItem, player);
+		}
+	}
+
+    public class AccessorySimulationPlayer : ModPlayer
+	{
+        public List<Item> simulatedAccessories = new List<Item>();
+
+		public override void Load()
+		{
+            AchievementsHelper.HandleOnEquip += OnEquipHandler;
+		}
+
+		private void OnEquipHandler(AchievementsHelper.orig_HandleOnEquip orig, Player player, Item item, int context)
+		{
+            if (item.ModItem is SmartAccessory)
+                (item.ModItem as SmartAccessory).Equip(player, item);
+
+            orig(player, item, context);
+		}
+
+		public override void OnEnterWorld(Player player)
+		{
+            simulatedAccessories.Clear();
+
+            for (int k = 3; k <= 7 + Player.extraAccessorySlots; k++)
+			{
+                (player.armor[k].ModItem as SmartAccessory)?.Equip(player, player.armor[k]);
+			}
+        }
+
+		public override void UpdateEquips()
+		{
+            simulatedAccessories.RemoveAll(n => n.IsAir);
+
+			foreach (var item in simulatedAccessories)
+			{
+                var modItem = item.ModItem;
+                modItem.UpdateAccessory(Player, true);
+                modItem.UpdateEquip(Player);
+			}
+		}
+	}
 }

--- a/Content/Items/Misc/Accessories.TestSimulator.cs
+++ b/Content/Items/Misc/Accessories.TestSimulator.cs
@@ -1,0 +1,66 @@
+﻿using StarlightRiver.Content.Abilities;
+using StarlightRiver.Content.Items.BaseTypes;
+using StarlightRiver.Core;
+using System.Collections.Generic;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace StarlightRiver.Content.Items.Misc
+{
+    public class TestSimulator : SmartAccessory
+    {
+        public override string Texture => AssetDirectory.MiscItem + "StarGlaive";
+
+        public override List<int> ChildTypes => new List<int>()
+        {
+            ModContent.ItemType<SwordBook>(),
+            ModContent.ItemType<Guillotine>()
+        };
+
+		public TestSimulator() : base("Testificate Charm", "debug item\nCombines the effects of some accessories\nAdditionally, boosts life by 100") { }
+
+        public override void SafeSetDefaults()
+        {
+            Item.rare = ItemRarityID.Orange;
+        }
+
+		public override void OnEquip(Player player, Item item)
+		{
+            Main.NewText("We just equipped!");
+		}
+
+		public override void SafeUpdateEquip(Player Player)
+        {
+            Player.statLifeMax2 += 100;
+        }
+    }
+
+    public class TestSimulator2 : SmartAccessory
+    {
+        public override string Texture => AssetDirectory.MiscItem + "StarGlaive";
+
+        public override List<int> ChildTypes => new List<int>()
+        {
+            ModContent.ItemType<TestSimulator>(),
+            ModContent.ItemType<PulseBoots>()
+        };
+
+        public TestSimulator2() : base("Testificate Charm 2", "debug item\nCombines the effects of some accessories in a chain") { }
+
+        public override void SafeSetDefaults()
+        {
+            Item.rare = ItemRarityID.Orange;
+        }
+
+        public override void OnEquip(Player player, Item item)
+        {
+            Main.NewText("The bigger accessory just equipped!");
+        }
+
+        public override void SafeUpdateEquip(Player Player)
+        {
+            Player.statLifeMax2 += 100;
+        }
+    }
+}

--- a/Content/Items/Misc/Accessories.TestSimulator.cs
+++ b/Content/Items/Misc/Accessories.TestSimulator.cs
@@ -18,7 +18,7 @@ namespace StarlightRiver.Content.Items.Misc
             ModContent.ItemType<Guillotine>()
         };
 
-		public TestSimulator() : base("Testificate Charm", "debug item\nCombines the effects of some accessories\nAdditionally, boosts life by 100") { }
+		public TestSimulator() : base("Testificate Charm", "debug item\nCombines the effects of Mantis Technique and Golden Guillotine\nAdditionally, boosts life by 100") { }
 
         public override void SafeSetDefaults()
         {
@@ -36,6 +36,34 @@ namespace StarlightRiver.Content.Items.Misc
         }
     }
 
+    public class TestSimulator3 : SmartAccessory
+    {
+        public override string Texture => AssetDirectory.MiscItem + "StarGlaive";
+
+        public override List<int> ChildTypes => new List<int>()
+        {
+            ModContent.ItemType<SwordBook>(),
+            ModContent.ItemType<StaminaUp>()
+        };
+
+        public TestSimulator3() : base("Testificate Charm 3", "debug item\nCombines the effects of Mantis Technique and Stamina Vessel\nAdditionally, boosts life by 100") { }
+
+        public override void SafeSetDefaults()
+        {
+            Item.rare = ItemRarityID.Orange;
+        }
+
+        public override void OnEquip(Player player, Item item)
+        {
+            Main.NewText("We just equipped!");
+        }
+
+        public override void SafeUpdateEquip(Player Player)
+        {
+            Player.statLifeMax2 += 100;
+        }
+    }
+
     public class TestSimulator2 : SmartAccessory
     {
         public override string Texture => AssetDirectory.MiscItem + "StarGlaive";
@@ -46,7 +74,7 @@ namespace StarlightRiver.Content.Items.Misc
             ModContent.ItemType<PulseBoots>()
         };
 
-        public TestSimulator2() : base("Testificate Charm 2", "debug item\nCombines the effects of some accessories in a chain") { }
+        public TestSimulator2() : base("Testificate Charm 2", "debug item\nCombines the effects of Testificate Charm and Pulse Boots") { }
 
         public override void SafeSetDefaults()
         {


### PR DESCRIPTION
### What are the specifics of what is being added? 
SmartAccessory now has a virtual ChildTypes property, which allows for an accessory to simulate the effects of another SmartAccessory. This is done via a list in a ModPlayer, which stores a list of "simulacrums", with each having a list of parents. Simulacrums act as if they're equipped, if all of a simulacrum's parents are gone, it dies. You cant equip a child with its parent or a parent with any of it's children.

### Is there an associated suggestion or dev server #code-needed post? How well does this PR follow it?
No

### Is there anything left to be done in this addition?
No, this is largely finished and includes usage examples already.