### PR TITLE
Added forced buffer size refresh on world enter

### DIFF
--- a/Core/StarlightPlayer.cs
+++ b/Core/StarlightPlayer.cs
@@ -157,6 +157,7 @@ namespace StarlightRiver.Core
         public override void OnEnterWorld(Player Player)
         {
             ZoomHandler.SetZoomAnimation(Main.GameZoomTarget, 1);
+            StarlightRiver.LightingBufferInstance.ResizeBuffers(Main.screenWidth, Main.screenHeight);
 
             rotation = 0;
 


### PR DESCRIPTION
## Fixes
Fixes the lighting buffer being sized incorrectly on initial world load sometimes, causing buggy visual artifacts when it is used. This is done by forcing a resize of the buffer when the player joins the world.