### PR TITLE
Fixed drop pods crashing worldgen

### DIFF
--- a/Content/WorldGeneration/GenerateDropPods.cs
+++ b/Content/WorldGeneration/GenerateDropPods.cs
@@ -19,8 +19,7 @@ namespace StarlightRiver.Core
         private void DropPodGen(GenerationProgress progress, GameConfiguration configuration)
         {
             progress.Message = "Crashing alien tech...";
-            int[] floatingIslandPositions = typeof(WorldGen).GetField("floatingIslandHouseX", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance).GetValue(null) as int[];
-            foreach (int x in floatingIslandPositions)
+            foreach (int x in WorldGen.floatingIslandHouseX)
             {
                 if (x == 0 || x == default)
                     continue;


### PR DESCRIPTION
Drop pods no longer crash worldgen. The crash was due to Tmod making WorldGen.floatingIslandHouseX public, so instead of grabbing it via reflection, I could just grab it directly