### PR TITLE
Made changes + fixed filet knife spawning

### DIFF
--- a/Content/Items/Misc/Weapons.FiletKnife.cs
+++ b/Content/Items/Misc/Weapons.FiletKnife.cs
@@ -130,7 +130,7 @@ namespace StarlightRiver.Content.Items.Misc
             if (DOT > 0)
             {
                 DOTreductionCounter++;
-                if (DOTreductionCounter > 200)
+                if (DOTreductionCounter > 330)
                 {
                     DOT--;
                     DOTreductionCounter = 0;

--- a/Content/Items/Misc/Weapons.FiletKnife.cs
+++ b/Content/Items/Misc/Weapons.FiletKnife.cs
@@ -123,11 +123,11 @@ namespace StarlightRiver.Content.Items.Misc
 
         public bool hasSword = false;
 
-        public override void SetDefaults(NPC NPC)
+        public override void OnSpawn(NPC npc, IEntitySource source)
         {
-            if (NPC.type == NPCID.BloodZombie && Main.rand.NextBool(50))
+            if (npc.type == NPCID.BloodZombie && Main.rand.NextBool(100))
                 hasSword = true;
-            base.SetDefaults(NPC);
+            base.OnSpawn(npc, source);
         }
 
         public override bool PreDraw(NPC NPC, SpriteBatch spriteBatch, Vector2 screenPos, Color drawColor)
@@ -147,9 +147,9 @@ namespace StarlightRiver.Content.Items.Misc
             return base.PreDraw(NPC, spriteBatch, screenPos, drawColor);
         }
 
-		public override void OnKill(NPC npc) //TODO: Figure out how to integrate this with the vanilla drop rule system later?
+		public override void OnKill(NPC npc)
         {
-            if (hasSword && Main.rand.NextBool(3))
+            if (hasSword)
                 Item.NewItem(npc.GetSource_Loot(), npc.Center, ModContent.ItemType<FiletKnife>());
 
             base.OnKill(npc);

--- a/Content/Items/Misc/Weapons.FiletKnife.cs
+++ b/Content/Items/Misc/Weapons.FiletKnife.cs
@@ -121,7 +121,22 @@ namespace StarlightRiver.Content.Items.Misc
 
         public int DOT = 0;
 
+        public int DOTreductionCounter = 0;
+
         public bool hasSword = false;
+
+        public override void ResetEffects(NPC npc)
+        {
+            if (DOT > 0)
+            {
+                DOTreductionCounter++;
+                if (DOTreductionCounter > 200)
+                {
+                    DOT--;
+                    DOTreductionCounter = 0;
+                }
+            }
+        }
 
         public override void OnSpawn(NPC npc, IEntitySource source)
         {


### PR DESCRIPTION
Made filet knife rarer to spawn on blood zombies, made it a 100% drop rate when it does, made filet knife DOT not last forever, and made it determined in onspawn rather than setdefaults, so bestiary dummies aren't affected.

Trello card: https://trello.com/c/g5say6xy/151-item-obtainment

Nothing left to do here, except maybe move it to the bestiary loot pool somehow? But I really don't know how you'd do that