### PR TITLE
Made sling not bug out when used without ammo

### DIFF
--- a/Content/Items/Misc/Weapons.Sling.cs
+++ b/Content/Items/Misc/Weapons.Sling.cs
@@ -27,6 +27,12 @@ namespace StarlightRiver.Content.Items.Misc
 
         public override bool SafeCanUseItem(Player player)
         {
+            if (!hasAmmo)
+            {
+                Item.noUseGraphic = false;
+                player.itemTime = 0;
+                return false;
+            }
             Item.noUseGraphic = true;
             player.itemTime = 2;
             if (currentAmmoStruct.ammoID == ItemID.Seed)


### PR DESCRIPTION
Whenever the sling is used without ammo, the CanUseItem() hook runs, which then sets Item.noUseGraphic to true, making the holdStyle not appear. This fix makes this not happen anymore.