### PR TITLE
 Disable Blover knockback for players with knockback reduction

### DIFF
--- a/Content/NPCs/Forest/Blover.cs
+++ b/Content/NPCs/Forest/Blover.cs
@@ -159,10 +159,10 @@ namespace StarlightRiver.Content.NPCs.Forest
             }
 
             float targetAcceleration = Math.Sign(target.Center.X - NPC.Center.X) * (float)((300 - Math.Abs(target.Center.X - NPC.Center.X)) / 300f) * 0.55f;
-            
-            if (Math.Abs(target.velocity.X) < 10 || Math.Sign(target.velocity.X) != Math.Sign(targetAcceleration))
-                target.velocity.X += targetAcceleration;
 
+            if (!target.noKnockback && (Math.Abs(target.velocity.X) < 10 || Math.Sign(target.velocity.X) != Math.Sign(targetAcceleration)))
+                target.velocity.X += targetAcceleration;
+            
             Vector2 dustPos = NPC.Center + new Vector2(60 * Math.Sign(target.Center.X - NPC.Center.X), Main.rand.Next(-15, 15));
             Dust.NewDustPerfect(dustPos, ModContent.DustType<Dusts.GlowLine>(), 7 * new Vector2(Math.Sign(target.Center.X - NPC.Center.X), 0), 0, Color.White * 0.3f, 1.25f);
         }


### PR DESCRIPTION
**What is being fixed or optimized? Is there an associated issue?**
Based on [this trello card](https://trello.com/c/7wHVFIm9/155-blover-change), Blover kb is reduced when the player has knockback resist. Wasn't sure if this should be completely disabled or not. Open to changes.

**What are the implementation specifics of this change? Are there any consequences?**
Disables Blover knockback when `Player.noKnockback` is true i.e. when the player has a cobalt shield equipped. No consequences that I am aware of.
