### PR TITLE
adjusted flare breacher offset

### DIFF
--- a/Content/Items/Breacher/Weapons.FlareBreacher.cs
+++ b/Content/Items/Breacher/Weapons.FlareBreacher.cs
@@ -51,7 +51,7 @@ namespace StarlightRiver.Content.Items.Breacher
 
         public override Vector2? HoldoutOffset()
         {
-            return new Vector2(-10, 0);
+            return new Vector2(2, 0);
         }
 
         public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
https://github.com/ProjectStarlight/StarlightRiver/issues/267

### What are the implementation specifics of this change? Are there any consequences?
value returned in the HoldOffset hook of the flare breacher item has been changed from -10 to +2