### PR TITLE
player dead fix

### DIFF
--- a/Core/GrazePlayer.cs
+++ b/Core/GrazePlayer.cs
@@ -55,7 +55,7 @@ namespace StarlightRiver.Core
 
         public override void PreUpdate()
         {
-            if (!doGrazeLogic)
+            if (!doGrazeLogic || Player.dead)
                 return;
 
             if (grazeCooldown > 0)


### PR DESCRIPTION
Stops Graze logic from running whilst player is dead, fixing a few bugs.