### PR TITLE
Fixed metaball system crashing game occaisionally during bootup

### DIFF
--- a/Core/Systems/MetaballSystem/MetaballSystem.cs
+++ b/Core/Systems/MetaballSystem/MetaballSystem.cs
@@ -52,7 +52,7 @@ namespace StarlightRiver.Core.Systems.MetaballSystem
 					UpdateWindowSize(Main.screenWidth, Main.screenHeight);
 			}
 
-			if (Main.spriteBatch != null && Main.graphics.GraphicsDevice != null)
+			if (Main.spriteBatch != null && Main.graphics.GraphicsDevice != null && !Main.gameMenu)
 				Actors.ForEach(a => a.DrawToTarget(Main.spriteBatch, Main.graphics.GraphicsDevice));
 
 			orig();


### PR DESCRIPTION
As the title says, this fixes an occaisional crash where drawing and loading metaball actors would happen at the same, causing a crash.

The only ramification I can think of is this fix means we can't have metaballs on the main menu, but that seems like a non issue.