### PR TITLE
Optimized and fixed magmagun

### DIFF
--- a/Content/Items/Misc/Weapons.MagmaGun.cs
+++ b/Content/Items/Misc/Weapons.MagmaGun.cs
@@ -55,14 +55,22 @@ namespace StarlightRiver.Content.Items.Misc
 				Terraria.Audio.SoundEngine.PlaySound(SoundID.Item13, position);
 			}
 
-			for (int i = 0; i < 3; i++)
+			if (proj != null && proj.active)
 			{
-				if (proj != null && proj.active)
+				proj.damage = damage / 2;
+				var mp = proj.ModProjectile as MagmaGunPhantomProj;
+
+				if (mp is null)
 				{
-					proj.damage = damage / 2;
-					var mp = proj.ModProjectile as MagmaGunPhantomProj;
+					proj = Projectile.NewProjectileDirect(player.GetSource_ItemUse(Item), player.Center, Vector2.Zero, ModContent.ProjectileType<MagmaGunPhantomProj>(), 0, 0, player.whoAmI);
+					return false;
+				}
+
+				for (int i = 0; i < 3; i++)
+				{
 					Vector2 direction = velocity.RotatedByRandom(0.1f);
 					direction *= Main.rand.NextFloat(0.9f, 1.15f);
+
 					Vector2 position2 = position;
 					position2 += Vector2.Normalize(velocity) * 20;
 					position2 += Vector2.Normalize(velocity.RotatedBy(1.57f * -player.direction)) * 5;

--- a/Content/Items/Misc/Weapons.MagmaGun.cs
+++ b/Content/Items/Misc/Weapons.MagmaGun.cs
@@ -77,6 +77,10 @@ namespace StarlightRiver.Content.Items.Misc
 					mp.CreateGlob(position2, direction);
 				}
 			}
+			else
+			{
+				proj = Projectile.NewProjectileDirect(player.GetSource_ItemUse(Item), player.Center, Vector2.Zero, ModContent.ProjectileType<MagmaGunPhantomProj>(), 0, 0, player.whoAmI);
+			}
 
 			return false;
 		}


### PR DESCRIPTION
Fixed and optimizes the magma gun to create it's dummy projectile while firing if one does not exist, and to not check it's dummy extraneously.