### PR TITLE
Added semaphore for metaball collection

### DIFF
--- a/Core/Systems/AuroraWaterSystem/AuroraWaterSystem.cs
+++ b/Core/Systems/AuroraWaterSystem/AuroraWaterSystem.cs
@@ -286,7 +286,9 @@ namespace StarlightRiver.Core.Systems.AuroraWaterSystem
 
 		public static void DrawSpecial()
 		{
-			if (!MetaballSystem.MetaballSystem.Actors.FirstOrDefault(n => n is AuroraWaterTileMetaballs).Active)
+			MetaballSystem.MetaballSystem.actorsSem.WaitOne();
+
+			if (!MetaballSystem.MetaballSystem.actors.FirstOrDefault(n => n is AuroraWaterTileMetaballs).Active)
 				return;
 
 			Effect shader = Terraria.Graphics.Effects.Filters.Scene["AuroraWaterShader"].GetShader().Shader;
@@ -302,11 +304,13 @@ namespace StarlightRiver.Core.Systems.AuroraWaterSystem
 			Main.spriteBatch.End();
 			Main.spriteBatch.Begin(default, BlendState.Additive, default, default, default, shader);
 
-			Texture2D target = MetaballSystem.MetaballSystem.Actors.FirstOrDefault(n => n is AuroraWaterTileMetaballs).Target.RenderTarget;
+			Texture2D target = MetaballSystem.MetaballSystem.actors.FirstOrDefault(n => n is AuroraWaterTileMetaballs).Target.RenderTarget;
 			Main.spriteBatch.Draw(target, Vector2.Zero, null, Color.White, 0, Vector2.Zero, 2, 0, 0);
 
 			Main.spriteBatch.End();
 			Main.spriteBatch.Begin(0, BlendState.AlphaBlend, Main.DefaultSamplerState, DepthStencilState.None, Main.Rasterizer, null, Main.Transform);
+
+			MetaballSystem.MetaballSystem.actorsSem.Release();
 		}
 
 		public override bool PostDraw(SpriteBatch spriteBatch, Texture2D target)

--- a/Core/Systems/MetaballSystem/MetaballActor.cs
+++ b/Core/Systems/MetaballSystem/MetaballActor.cs
@@ -30,7 +30,9 @@ namespace StarlightRiver.Core.Systems.MetaballSystem
 			Target = new(DrawShapes, () => Active, 1);
 			Target2 = new(DrawSecondTarget, () => Active, 1.1f);
 
-			MetaballSystem.Actors.Add(this);
+			MetaballSystem.actorsSem.WaitOne();
+			MetaballSystem.actors.Add(this);
+			MetaballSystem.actorsSem.Release();
 		}
 
 		public void Unload()

--- a/Core/Systems/MetaballSystem/MetaballSystem.cs
+++ b/Core/Systems/MetaballSystem/MetaballSystem.cs
@@ -1,11 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace StarlightRiver.Core.Systems.MetaballSystem
 {
 	public class MetaballSystem : IOrderedLoadable
 	{
-		public static List<MetaballActor> Actors = new();
+		public static Semaphore actorsSem = new(1, 1);
+
+		public static List<MetaballActor> actors = new();
 
 		//We intentionally load after screen targets here so our extra RT swapout applies after the default ones.
 		public float Priority => 1.1f;
@@ -24,23 +27,29 @@ namespace StarlightRiver.Core.Systems.MetaballSystem
 			On.Terraria.Main.DrawNPCs -= DrawTargets;
 			On.Terraria.Main.CheckMonoliths -= BuildTargets;
 
-			Actors = null;
+			actorsSem.WaitOne();
+			actors = null;
+			actorsSem.Release();
 		}
 
 		private void DrawTargets(On.Terraria.Main.orig_DrawNPCs orig, Main self, bool behindTiles = false)
 		{
 			if (behindTiles)
 			{
-				var toDraw = Actors.Where(n => !n.OverEnemies).ToList();
+				actorsSem.WaitOne();
+				var toDraw = actors.Where(n => !n.OverEnemies).ToList();
 				toDraw.ForEach(a => a.DrawTarget(Main.spriteBatch));
+				actorsSem.Release();
 			}
 
 			orig(self, behindTiles);
 
 			if (!behindTiles)
 			{
-				var toDraw = Actors.Where(n => n.OverEnemies).ToList();
+				actorsSem.WaitOne();
+				var toDraw = actors.Where(n => n.OverEnemies).ToList();
 				toDraw.ForEach(a => a.DrawTarget(Main.spriteBatch));
+				actorsSem.Release();
 			}
 		}
 
@@ -49,7 +58,11 @@ namespace StarlightRiver.Core.Systems.MetaballSystem
 			orig();
 
 			if (!Main.gameMenu && Main.spriteBatch != null && Main.graphics.GraphicsDevice != null)
-				Actors.ForEach(a => a.DrawToTarget(Main.spriteBatch, Main.graphics.GraphicsDevice));
+			{
+				actorsSem.WaitOne();
+				actors.ForEach(a => a.DrawToTarget(Main.spriteBatch, Main.graphics.GraphicsDevice));
+				actorsSem.Release();
+			}
 		}
 	}
 }


### PR DESCRIPTION
This should fix the load crash when metaballs get added to the collection while its trying to be iterated over