### PR TITLE
Aztec Death Sax fix

### DIFF
--- a/Content/Items/BuriedArtifacts/Weapons.AztecDeathSaxophone.cs
+++ b/Content/Items/BuriedArtifacts/Weapons.AztecDeathSaxophone.cs
@@ -140,7 +140,7 @@ namespace StarlightRiver.Content.Items.BuriedArtifacts
 
 		public override bool CanUseItem(Player player)
 		{
-			return player.ownedProjectileCounts[ModContent.ProjectileType<AztecDeathSaxophoneHoldout>()] <= 0;
+			return player.ownedProjectileCounts[ModContent.ProjectileType<AztecDeathSaxophoneHoldout>()] <= 0 && charge >= MAX_CHARGE;
 		}
 
 		public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)

--- a/Content/Items/BuriedArtifacts/Weapons.AztecDeathSaxophone.cs
+++ b/Content/Items/BuriedArtifacts/Weapons.AztecDeathSaxophone.cs
@@ -34,22 +34,26 @@ namespace StarlightRiver.Content.Items.BuriedArtifacts
 
 		private void StarlightPlayer_OnHitNPCWithProjEvent(Player player, Projectile proj, NPC target, int damage, float knockback, bool crit)
 		{
-			HitEffects(player, target);
+			if (player.HasItem(Type))
+				HitEffects(player, target);
 		}
 
 		private void StarlightPlayer_OnHitNPCEvent(Player player, Item Item, NPC target, int damage, float knockback, bool crit)
 		{
-			HitEffects(player, target);
+			if (player.HasItem(Type))
+				HitEffects(player, target);
 		}
 
 		private void StarlightPlayer_OnHitByProjectileEvent(Player player, Projectile projectile, int damage, bool crit)
 		{
-			HurtEffects(player, damage, projectile);
+			if (player.HasItem(Type))
+				HurtEffects(player, damage, projectile);
 		}
 
 		private void StarlightPlayer_OnHitByNPCEvent(Player player, NPC npc, int damage, bool crit)
 		{
-			HurtEffects(player, damage, npc);
+			if (player.HasItem(Type))
+				HurtEffects(player, damage, npc);
 		}
 
 		public void HitEffects(Player Player, NPC target)


### PR DESCRIPTION
prevents hit/kill particles from spawning if you dont have the sax in your inventory