### PR TITLE
Fixed a bug where the Auroracle ArenaBlocker could be moved by Fae Whip

### DIFF
--- a/Content/Bosses/SquidBoss/NPCs.ArenaBlocker.cs
+++ b/Content/Bosses/SquidBoss/NPCs.ArenaBlocker.cs
@@ -34,6 +34,7 @@ namespace StarlightRiver.Content.Bosses.SquidBoss
 			NPC.noGravity = true;
 			NPC.noTileCollide = true;
 			NPC.dontTakeDamage = true;
+			NPC.knockBackResist = 0; // Fae Whip fix
 		}
 
 		public override void AI()


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
Fixed a bug where the Auroracle ArenaBlocker could be moved by Fae Whip.
No associated issue (honestly it was easier to fix than write an issue)
### What are the implementation specifics of this change? Are there any consequences?
1 new line