### PR TITLE
Makes PrismaticDrown actually drown the player outside of the boss fight

### DIFF
--- a/Content/Buffs/PrismaticDrown.cs
+++ b/Content/Buffs/PrismaticDrown.cs
@@ -22,7 +22,18 @@
 			}
 			else
 			{
-				Player.breath--;
+				// makes the player drown. I had to do this manually because the player is considered out of water
+				Player.breath = (int)MathHelper.Max(-6, Player.breath - 4);
+
+				if (Player.breath <= 0)
+				{
+					// decreases health then kills player
+					Player.statLife--;
+					if (Player.statLife <= 0)
+					{
+						Player.KillMe(Terraria.DataStructures.PlayerDeathReason.ByOther(1), 1, 0);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
The Prismatic Drown debuff will now drown the player if in the water outside of a boss fight. It is a bit of a strange way of doing it, but it's the only way I could find that didn't involve adding a bunch more code. The original way it was done did nothing because the breath that was removed immediately came back.
### What are the implementation specifics of this change? Are there any consequences?
When in the boss fight arena of the Auroracle without recall potions or a mirror, you can kill yourself to get out without logging out. It does do it rather quickly because of the way I've coded it though; I can't slow the breath loss down. This may also make it so it's kinda easy to accidentally die if you don't have good movement.