### PR TITLE
Bug fixes

### DIFF
--- a/Content/Items/Forest/Tools.Trowel.cs
+++ b/Content/Items/Forest/Tools.Trowel.cs
@@ -78,7 +78,6 @@ namespace StarlightRiver.Content.Items.Forest
 				case TileID.LivingMahoganyLeaves:
 					return ItemID.RichMahogany;
 
-					//may need to be item instead of tile for hive and bone wand...
 				case TileID.BoneBlock:
 					return ItemID.Bone;
 

--- a/Content/Items/Forest/Tools.Trowel.cs
+++ b/Content/Items/Forest/Tools.Trowel.cs
@@ -65,6 +65,30 @@ namespace StarlightRiver.Content.Items.Forest
 			return default;
 		}
 
+		//returns the item ID that is consumed
+		private static int BlockWandSubstitutions(int createTile)
+		{//this could check item id instead if needed
+			switch (createTile)
+			{
+				case TileID.LivingWood:
+				case TileID.LeafBlock:
+					return ItemID.Wood;
+
+				case TileID.LivingMahogany:
+				case TileID.LivingMahoganyLeaves:
+					return ItemID.RichMahogany;
+
+					//may need to be item instead of tile for hive and bone wand...
+				case TileID.BoneBlock:
+					return ItemID.Bone;
+
+				case TileID.Hive:
+					return ItemID.Hive;
+			}
+
+			return -1;
+		}
+
 		public override bool? UseItem(Player Player)
 		{
 			Tile tile = Framing.GetTileSafely(Player.tileTargetX, Player.tileTargetY);
@@ -73,11 +97,13 @@ namespace StarlightRiver.Content.Items.Forest
 			if (!tile.HasTile || Main.tileFrameImportant[tile.TileType])
 				return true;
 
+			int itemSubstitution = BlockWandSubstitutions(tile.TileType);//if this block should look for a different item than the one used to place it
+
 			for (int k = 0; k < Player.inventory.Length; k++)  //find the Item to place the tile
 			{
 				Item thisItem = Player.inventory[k];
 
-				if (!thisItem.IsAir && thisItem.createTile == tile.TileType)
+				if (!thisItem.IsAir && (thisItem.type == itemSubstitution || (itemSubstitution == -1 && thisItem.createTile == tile.TileType)))
 					Item = Player.inventory[k];
 			}
 
@@ -89,9 +115,12 @@ namespace StarlightRiver.Content.Items.Forest
 			if (next != default)
 			{
 				WorldGen.PlaceTile(next.X, next.Y, tile.TileType);
-				Item.stack--;
-				if (Item.stack <= 0)
-					Item.TurnToAir();
+				if (Item.consumable)//so that infinite items do not get used up
+				{
+					Item.stack--;
+					if (Item.stack <= 0)
+						Item.TurnToAir();
+				}	
 			}
 
 			return true;

--- a/Content/Items/Forest/Tools.Trowel.cs
+++ b/Content/Items/Forest/Tools.Trowel.cs
@@ -83,6 +83,9 @@ namespace StarlightRiver.Content.Items.Forest
 
 				case TileID.Hive:
 					return ItemID.Hive;
+
+				default:
+					break;
 			}
 
 			return -1;
@@ -102,7 +105,7 @@ namespace StarlightRiver.Content.Items.Forest
 			{
 				Item thisItem = Player.inventory[k];
 
-				if (!thisItem.IsAir && (thisItem.type == itemSubstitution || (itemSubstitution == -1 && thisItem.createTile == tile.TileType)))
+				if (!thisItem.IsAir && (thisItem.type == itemSubstitution || itemSubstitution == -1 && thisItem.createTile == tile.TileType))
 					Item = Player.inventory[k];
 			}
 

--- a/Content/WorldGeneration/GenerateMoonstone.cs
+++ b/Content/WorldGeneration/GenerateMoonstone.cs
@@ -78,9 +78,9 @@ namespace StarlightRiver.Content.WorldGeneration
 		{
 			bool ignorePlayers = false;
 
-			if (i < 50 || i > Main.maxTilesX - 50)
+			if (i < 75 || i > Main.maxTilesX - 75)
 				return false;
-			if (j < 50 || j > Main.maxTilesY - 50)
+			if (j < 75 || j > Main.maxTilesY - 75)
 				return false;
 
 			int num = 35;


### PR DESCRIPTION
Fixed block wands with bricklayers trowel, and Increased moonstone distance from world edge.

Block wands are no longer consumed, and it instead consumes the base block type.

Moonstone can spawn a minimum of 75 blocks from world edge instead of the previous 50,
previously if a moonstone shard spawned close enough to the world edge some of it would be outside the accessible world. There was also a report of a shard spawning completely outside the world but I could not reproduce this. Its possible this may need to be increased even more later on if this is still an issue.