### PR TITLE
Fix CoordinateWidth for VitricCrystals

### DIFF
--- a/Core/WalkableCrystal.cs
+++ b/Core/WalkableCrystal.cs
@@ -61,6 +61,7 @@ namespace StarlightRiver.Core
 			Main.tileFrameImportant[Type] = true;
 			TileID.Sets.DrawsWalls[Type] = true;
 
+			TileObjectData.newTile.CoordinateWidth = 16;
 			TileObjectData.newTile.UsesCustomCanPlace = true;
 			TileObjectData.newTile.HookPlaceOverride = new PlacementHook(PostPlace, -1, 0, true);
 			TileObjectData.addTile(Type);


### PR DESCRIPTION
## What is being fixed?
The `TileObjectData` for `VitricCrystals` had a `CoordinateWidth` and by extension a `CoordinateFullWidth` of 0 which would cause `TileObjectData.GetTileData` to throw a `DivideByZeroException`
## Is there an associated issue?
No
## What are the implementation specifics of this change?
`CoordinateWidth` was set to 16.
## Are there any consequences?
I don't think so