### PR TITLE
Balance

### DIFF
--- a/Content/Abilities/AbilityHandler.cs
+++ b/Content/Abilities/AbilityHandler.cs
@@ -12,7 +12,64 @@ namespace StarlightRiver.Content.Abilities
 {
 	public class AbilityHandler : ModPlayer, IOrderedLoadable
 	{
-		// The Player's active ability.
+		private const int SHARDS_PER_VESSEL = 3;
+
+		private InfusionItem[] infusions = new InfusionItem[Infusion.InfusionSlots];
+		public Dictionary<Type, Ability> unlockedAbilities = new();
+
+		private float stamina;
+		private float staminaMaxBonus;
+		private int staminaRegenCD;
+
+		private Ability activeAbility;
+		private Ability nextAbility;
+
+		public float Priority => 1;
+
+		/// <summary>
+		/// The players effective maximum stamina
+		/// </summary>
+		public float StaminaMax => StaminaMaxDefault + StaminaMaxBonus;
+		public float StaminaMaxDefault => Shards.Count / SHARDS_PER_VESSEL + unlockedAbilities.Count;
+
+		/// <summary>
+		/// The rate at which the player regenerates stamina. One point is equal to 0.05 stamina per second.
+		/// </summary>
+		public int StaminaRegenRate { get; set; }
+
+		/// <summary>
+		/// The maximum amount of infusions the player can equip
+		/// </summary>
+		public int InfusionLimit { get; set; } = 0;
+
+		/// <summary>
+		/// Global stamina cost multiplier. Used to increase or decrease the cost of ALL abilities by a multiplicative value
+		/// </summary>
+		public float StaminaCostMultiplier { get; set; }
+
+		/// <summary>
+		/// Global stamina cost flat modifier. Used to increase or decrease the cost of ALL abilities by a flat value
+		/// </summary>
+		public float StaminaCostBonus { get; set; }
+
+		/// <summary>
+		/// The amount of stamina vessel shards the player has
+		/// </summary>
+		public int ShardCount => Shards.Count;
+
+		/// <summary>
+		/// If the player has unlocked any abilties or not. Used for UI visibility
+		/// </summary>
+		public bool AnyUnlocked => unlockedAbilities.Count > 0;
+
+		/// <summary>
+		/// The stamina vessel shards the player has collected, as each is unique
+		/// </summary>
+		public ShardSet Shards { get; private set; } = new ShardSet();
+
+		/// <summary>
+		/// The player's currently active ability
+		/// </summary>
 		public Ability ActiveAbility
 		{
 			get => activeAbility;
@@ -26,9 +83,9 @@ namespace StarlightRiver.Content.Abilities
 			}
 		}
 
-		// The Player's stamina stats.
-		public float StaminaMax => StaminaMaxDefault + StaminaMaxBonus;
-		public float StaminaMaxDefault => Shards.Count / shardsPerVessel + unlockedAbilities.Count;
+		/// <summary>
+		/// A flat modifier to the player's max stamina. Can be used to increase or decrease it, but not lower than zero.
+		/// </summary>
 		public float StaminaMaxBonus
 		{
 			get => staminaMaxBonus;
@@ -36,37 +93,16 @@ namespace StarlightRiver.Content.Abilities
 				// Can't have less than 0 max sp.
 				staminaMaxBonus = Math.Max(value, -StaminaMaxDefault);
 		}
+
+		/// <summary>
+		/// The player's base stamina, should only be effected by ability and vessel unlocks.
+		/// </summary>
 		public float Stamina
 		{
 			get => stamina;
 			// Can't have less than 0 or more than max stamina.
 			set => stamina = MathHelper.Clamp(value, 0, StaminaMax);
 		}
-		public float StaminaRegenRate { get; set; }
-		public int InfusionLimit { get; set; } = 0;
-
-		public float StaminaCostMultiplier { get; set; }
-		public float StaminaCostBonus { get; set; }
-
-		public int ShardCount => Shards.Count;
-		public bool AnyUnlocked => unlockedAbilities.Count > 0;
-
-		// Some constants.
-		private const int shardsPerVessel = 3;
-
-		public ShardSet Shards { get; private set; } = new ShardSet();
-
-		// Internal-only information.
-
-		private InfusionItem[] infusions = new InfusionItem[Infusion.InfusionSlots];
-		public Dictionary<Type, Ability> unlockedAbilities = new();
-		private int staminaRegenCD;
-		private float stamina;
-		private float staminaMaxBonus;
-		private Ability activeAbility;
-		private Ability nextAbility;
-
-		public float Priority => 1;
 
 		//for some reason without specifically setting these values to zero with cloneNewInstances => false and contructor,
 		////on a server if someone unlocks or modifies these it will impact newly created characters from then on for that instance
@@ -85,18 +121,33 @@ namespace StarlightRiver.Content.Abilities
 
 		public override void Unload() { }
 
+		/// <summary>
+		/// Internal method for handling an ability unlock, used by the publically exposed generic methods
+		/// </summary>
+		/// <param name="t"></param>
+		/// <param name="ability"></param>
 		private void Unlock(Type t, Ability ability)
 		{
 			unlockedAbilities[t] = ability;
 			ability.User = this;
 		}
 
+		/// <summary>
+		/// Internal method for checking and retrieving an infusion if the player has it on.
+		/// </summary>
+		/// <param name="t"></param>
+		/// <param name="infusion"></param>
+		/// <returns></returns>
 		private bool TryMatchInfusion(Type t, out InfusionItem infusion)
 		{
 			infusion = infusions.FirstOrDefault(i => i?.AbilityType == t);
 			return infusion != null;
 		}
 
+		/// <summary>
+		/// Re-locks an ability for the player. Typically only used for debugging purposes.
+		/// </summary>
+		/// <typeparam name="T">The type of the ability to lock</typeparam>
 		public void Lock<T>() where T : Ability
 		{
 			unlockedAbilities.Remove(typeof(T));
@@ -204,11 +255,20 @@ namespace StarlightRiver.Content.Abilities
 			return true;
 		}
 
+		/// <summary>
+		/// Retrieves the infusion item for the given infusion slot
+		/// </summary>
+		/// <param name="slot">The index of the slot to retrieve</param>
+		/// <returns>The InfusionItem ModItem of the infusion in the given slot, or null if one is not there.</returns>
 		public InfusionItem GetInfusion(int slot)
 		{
 			return slot < 0 || slot >= infusions.Length ? null : infusions[slot];
 		}
 
+		/// <summary>
+		/// Sets the player's stamina regen delay, in ticks. Anything larger than 60 will prevent the player from regenerating stamina untill the time minus 60 expires.
+		/// </summary>
+		/// <param name="cooldownTicks">How long the player's stamina delay is set for</param>
 		public void SetStaminaRegenCD(int cooldownTicks)
 		{
 			staminaRegenCD = Math.Max(staminaRegenCD, cooldownTicks);
@@ -262,7 +322,7 @@ namespace StarlightRiver.Content.Abilities
 		{
 			//Resets the Player's stamina to prevent issues with gaining infinite stamina or stamina regeneration.
 			staminaMaxBonus = 0;
-			StaminaRegenRate = 1 / 60f * 2; // stamina per tick = 1 / 60f * (stamina per second)
+			StaminaRegenRate = 5;
 			StaminaCostMultiplier = 1;
 			StaminaCostBonus = 0;
 
@@ -314,7 +374,7 @@ namespace StarlightRiver.Content.Abilities
 				Player.rocketBoots = -1;
 				Player.wings = -1;
 
-				SetStaminaRegenCD(200);
+				SetStaminaRegenCD(60);
 			}
 			else
 			{
@@ -329,6 +389,9 @@ namespace StarlightRiver.Content.Abilities
 			}
 		}
 
+		/// <summary>
+		/// Handles updating the player's stamina values based on their regeneration stat
+		/// </summary>
 		private void UpdateStaminaRegen()
 		{
 			const int cooldownSmoothing = 10;
@@ -342,9 +405,13 @@ namespace StarlightRiver.Content.Abilities
 				staminaRegenCD--;
 
 			// Regen stamina at a speed inversely proportional to the smoothed cooldown
-			Stamina += StaminaRegenRate / (staminaRegenCD / (float)cooldownSmoothing + 1);
+			Stamina += StaminaRegenRate * 0.05f / 60f * (1 - staminaRegenCD / 60f);
 		}
 
+		/// <summary>
+		/// This handles running the updates of the active ability/infusion, and properly dealing with those that have
+		/// expired already.
+		/// </summary>
 		private void UpdateAbilities()
 		{
 			var called = new HashSet<Ability>();
@@ -387,6 +454,9 @@ namespace StarlightRiver.Content.Abilities
 			}
 		}
 
+		/// <summary>
+		/// This handles activation and deactivation of the currently active ability
+		/// </summary>
 		private void UpdateActiveAbilityHooks()
 		{
 			// Call the current ability's deactivation hooks
@@ -426,6 +496,11 @@ namespace StarlightRiver.Content.Abilities
 			ActiveAbility?.ModifyDrawInfo(ref drawInfo);
 		}
 
+		/// <summary>
+		/// This handles calling the visual effect hooks of active abilities
+		/// </summary>
+		/// <param name="Player"></param>
+		/// <param name="spriteBatch"></param>
 		public void PostDrawAbility(Player Player, SpriteBatch spriteBatch)
 		{
 			var called = new HashSet<Ability>();

--- a/Content/Bosses/SquidBoss/NPCs.ArenaActor.cs
+++ b/Content/Bosses/SquidBoss/NPCs.ArenaActor.cs
@@ -7,6 +7,7 @@ using StarlightRiver.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Terraria.DataStructures;
 using Terraria.GameContent.Bestiary;
 using Terraria.ID;
 using static Terraria.ModLoader.ModContent;
@@ -192,7 +193,12 @@ namespace StarlightRiver.Content.Bosses.SquidBoss
 				Player player = Main.player[k];
 
 				if (player.active && player.Hitbox.Intersects(new Rectangle((int)pos.X, (int)pos.Y, 104 * 16, (int)WaterLevel)))
+				{
+					if (!player.HasBuff(BuffType<Buffs.PrismaticDrown>()) && NPC.AnyNPCs(ModContent.NPCType<Content.Bosses.SquidBoss.SquidBoss>()))
+						player.Hurt(PlayerDeathReason.ByCustomReason("fell into the drink"), Main.masterMode ? 50 : Main.expertMode ? 20 : 10, 0);
+
 					player.AddBuff(BuffType<Buffs.PrismaticDrown>(), 4, false);
+				}
 			}
 
 			for (int k = 0; k < Main.maxItems; k++)

--- a/Content/Items/Misc/Accessories.StaminaRing.cs
+++ b/Content/Items/Misc/Accessories.StaminaRing.cs
@@ -10,7 +10,7 @@ namespace StarlightRiver.Content.Items.Misc
 	{
 		public override string Texture => AssetDirectory.MiscItem + Name;
 
-		public StaminaRing() : base("Band of Starlight", "Slightly increases Starlight regeneration") { }
+		public StaminaRing() : base("Band of Starlight", "+2 Starlight regeneration") { }
 
 		public override void SafeSetDefaults()
 		{
@@ -21,7 +21,7 @@ namespace StarlightRiver.Content.Items.Misc
 		public override void SafeUpdateEquip(Player Player)
 		{
 			AbilityHandler mp = Player.GetHandler();
-			mp.StaminaRegenRate += 0.05f;
+			mp.StaminaRegenRate += 2;
 		}
 
 		public override void AddRecipes()

--- a/Content/Items/Misc/SoilgunFiles/Weapons.Soilgun.cs
+++ b/Content/Items/Misc/SoilgunFiles/Weapons.Soilgun.cs
@@ -12,6 +12,8 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 
 	public class Soilgun : MultiAmmoWeapon
 	{
+		public override string Texture => AssetDirectory.MiscItem + Name;
+
 		public override List<AmmoStruct> ValidAmmos => new()
 		{
 			new AmmoStruct(ItemID.SandBlock, ModContent.ProjectileType<SoilgunSandSoil>(), 2),
@@ -24,17 +26,6 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 			new AmmoStruct(Mod.Find<ModItem>("VitricSandItem").Type, ModContent.ProjectileType<SoilgunVitricSandSoil>(), 8),
 			new AmmoStruct(ItemID.MudBlock, ModContent.ProjectileType<SoilgunMudSoil>(), 3),
 		};
-		public override bool CanConsumeAmmo(Item ammo, Player player)
-		{
-			return false;
-		}
-
-		public override bool SafeCanUseItem(Player player)
-		{
-			return player.ownedProjectileCounts[ModContent.ProjectileType<SoilgunHoldout>()] <= 0;
-		}
-
-		public override string Texture => AssetDirectory.MiscItem + Name;
 
 		public override void SetStaticDefaults()
 		{
@@ -45,7 +36,7 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 		public override void SafeSetDefaults()
 		{
 			Item.DamageType = DamageClass.Ranged;
-			Item.damage = 14;
+			Item.damage = 4;
 			Item.width = 60;
 			Item.height = 36;
 			Item.useAnimation = Item.useTime = 55;
@@ -61,9 +52,19 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 			Item.value = Item.sellPrice(gold: 1);
 		}
 
+		public override bool CanConsumeAmmo(Item ammo, Player player)
+		{
+			return false;
+		}
+
+		public override bool SafeCanUseItem(Player player)
+		{
+			return player.ownedProjectileCounts[ModContent.ProjectileType<SoilgunHoldout>()] <= 0;
+		}
+
 		public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
 		{
-			Projectile proj = Projectile.NewProjectileDirect(source, position, velocity, ModContent.ProjectileType<SoilgunHoldout>(), damage, knockback, player.whoAmI, 0, type);
+			var proj = Projectile.NewProjectileDirect(source, position, velocity, ModContent.ProjectileType<SoilgunHoldout>(), damage, knockback, player.whoAmI, 0, type);
 			if (proj.ModProjectile is SoilgunHoldout soilGun)
 				soilGun.SoilAmmoID = currentAmmoStruct.ammoID;
 			return false;
@@ -82,23 +83,36 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 
 	class SoilgunGlobalItem : GlobalItem
 	{
+		public TooltipLine ammoTooltip;
+
 		public override bool InstancePerEntity => true;
 
-		public TooltipLine infoTooltip2;
-		public List<int> ValidSoils => new() { ItemID.SandBlock, ItemID.EbonsandBlock, ItemID.PearlsandBlock, ItemID.CrimsandBlock, ItemID.DirtBlock, ItemID.SiltBlock,
-			ItemID.SlushBlock, Mod.Find<ModItem>("VitricSandItem").Type, ItemID.MudBlock};
+		public List<int> ValidSoils => new()
+		{
+			ItemID.SandBlock,
+			ItemID.EbonsandBlock,
+			ItemID.PearlsandBlock,
+			ItemID.CrimsandBlock,
+			ItemID.DirtBlock,
+			ItemID.SiltBlock,
+			ItemID.SlushBlock,
+			Mod.Find<ModItem>("VitricSandItem").Type,
+			ItemID.MudBlock
+		};
+
 		public override void ModifyTooltips(Item item, List<TooltipLine> tooltips)
 		{
 			if (Main.LocalPlayer.HasItem(ModContent.ItemType<Soilgun>()) || Main.LocalPlayer.HasItem(ModContent.ItemType<Earthduster>()))
 			{
 				if (ValidSoils.Contains(item.type))
 				{
-					TooltipLine tooltip = new TooltipLine(Mod, "SoilgunAmmoTooltip", "This item can be used as ammo for the Soilgun and Earthduster");
+					var tooltip = new TooltipLine(Mod, "SoilgunAmmoTooltip", "This item can be used as ammo for the Soilgun and Earthduster");
 					tooltips.Add(tooltip);
 					tooltip.OverrideColor = new Color(202, 148, 115);
+
 					if (item.type == Mod.Find<ModItem>("VitricSandItem").Type)
 					{
-						TooltipLine infoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of glassy sand, that cause crystals to grow out of enemies\nFor each crystal an enemy has, they take 2 damage per second, plus a base damage of 4, up to a maximum of 10 crystals\nIf an enemy has had 10 crystals on them for more than 4 seconds, all crystals become charged, exploding shorty after");
+						var infoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of glassy sand, that cause crystals to grow out of enemies\nFor each crystal an enemy has, they take 2 damage per second, plus a base damage of 4, up to a maximum of 10 crystals\nIf an enemy has had 10 crystals on them for more than 4 seconds, all crystals become charged, exploding shorty after");
 						tooltips.Add(infoTooltip);
 						infoTooltip.OverrideColor = new Color(202, 148, 115);
 						return;
@@ -106,23 +120,24 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 
 					switch (item.type)
 					{
-						case ItemID.SandBlock: infoTooltip2 = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of sand that split into many grains of sand upon death"); break;
-						case ItemID.CrimsandBlock: infoTooltip2 = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of Crimsand that steal life from hit enemies"); break;
-						case ItemID.EbonsandBlock: infoTooltip2 = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of Ebonsand that apply stacks of Haunted to enemies"); break;
-						case ItemID.PearlsandBlock: infoTooltip2 = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of Pearlsand that home in on enemies"); break;
-						case ItemID.DirtBlock: infoTooltip2 = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of dirt"); break;
-						case ItemID.SiltBlock: infoTooltip2 = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of silt, that spawn coins upon hitting enemies"); break;
-						case ItemID.SlushBlock: infoTooltip2 = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of slush that cause hit enemies to have icicles impale them\nHitting and enemy with more than 10 icicles causes all icicles to shatter, causing large amounts of damage"); break;
-						case ItemID.MudBlock: infoTooltip2 = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of mud that bounce off tiles and enemies"); break;
+						case ItemID.SandBlock: ammoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of sand that split into many grains of sand upon death"); break;
+						case ItemID.CrimsandBlock: ammoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of Crimsand that steal life from hit enemies"); break;
+						case ItemID.EbonsandBlock: ammoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of Ebonsand that apply stacks of Haunted to enemies"); break;
+						case ItemID.PearlsandBlock: ammoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of Pearlsand that home in on enemies"); break;
+						case ItemID.DirtBlock: ammoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of dirt"); break;
+						case ItemID.SiltBlock: ammoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of silt, that spawn coins upon hitting enemies"); break;
+						case ItemID.SlushBlock: ammoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of slush that cause hit enemies to have icicles impale them\nHitting and enemy with more than 10 icicles causes all icicles to shatter, causing large amounts of damage"); break;
+						case ItemID.MudBlock: ammoTooltip = new TooltipLine(Mod, "AmmoInfoTooltip", "When used with the Soilgun or Earthduster, it will fire out blocks of mud that bounce off tiles and enemies"); break;
 					}
 
-					tooltips.Add(infoTooltip2);
-					infoTooltip2.OverrideColor = new Color(202, 148, 115);
+					tooltips.Add(ammoTooltip);
+					ammoTooltip.OverrideColor = new Color(202, 148, 115);
 				}
 			}
 		}
 	}
 
+	//TODO: Port to stackable buffs
 	class SoilgunGlobalNPC : GlobalNPC
 	{
 		public const int MAXHAUNTEDSTACKS = 20;
@@ -398,7 +413,7 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 			int DustFrequency = (int)(15 - Utils.Clamp(CurrentCharge / 5, 0, 12));
 			if (Main.rand.NextBool(Utils.Clamp(DustFrequency, 1, 15)))
 			{
-				Dust dust = Dust.NewDustDirect(barrelPos, 2, 8, ChooseChargeDust(), 0f, 0f);
+				var dust = Dust.NewDustDirect(barrelPos, 2, 8, ChooseChargeDust(), 0f, 0f);
 				dust.scale = Main.rand.NextFloat(0.8f, 1.2f);
 				dust.noGravity = false;
 				if (Main.rand.NextBool(5))
@@ -414,7 +429,7 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 				SpriteEffects spriteEffects = Projectile.spriteDirection == 1 ? SpriteEffects.None : SpriteEffects.FlipHorizontally;
 
 				float progress = 1 - DrawWhiteTimer / 30f;
-				Color drawColor = Color.Lerp(Color.White, Color.Transparent, progress);
+				var drawColor = Color.Lerp(Color.White, Color.Transparent, progress);
 
 				Main.EntitySpriteDraw(texture, Projectile.Center - Main.screenPosition, null, drawColor, Projectile.rotation, texture.Size() / 2, 1f, spriteEffects, 0);
 			}
@@ -447,7 +462,7 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 			{
 				Vector2 dustVelocity = shootVelocity.RotatedByRandom(MathHelper.ToRadians(8)) * Main.rand.NextFloat(0.25f, 0.45f);
 
-				Dust dust = Dust.NewDustDirect(position, 2, 8, DustID.Dirt, dustVelocity.X, dustVelocity.Y);
+				var dust = Dust.NewDustDirect(position, 2, 8, DustID.Dirt, dustVelocity.X, dustVelocity.Y);
 				dust.scale = Main.rand.NextFloat(1.1f, 1.55f);
 				dust.noGravity = true;
 			}

--- a/Content/Items/Misc/SoilgunFiles/Weapons.SoilgunSoilProjectiles.cs
+++ b/Content/Items/Misc/SoilgunFiles/Weapons.SoilgunSoilProjectiles.cs
@@ -226,7 +226,9 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 	public class SoilgunCrimsandSoil : BaseSoilProjectile
 	{
 		public override string Texture => "Terraria/Images/Item_" + ItemID.CrimsandBlock;
+
 		public SoilgunCrimsandSoil() : base(new Color(39, 17, 14), new Color(56, 17, 14), new Color(135, 43, 34), DustID.CrimsonPlants) { }
+
 		public override void SafeAI()
 		{
 			if (Main.rand.NextBool(10))
@@ -238,7 +240,7 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			if (Main.rand.NextBool(3) && Main.player[Projectile.owner].statLife < Main.player[Projectile.owner].statLifeMax2)
+			if (Main.rand.NextBool(5) && Main.player[Projectile.owner].statLife < Main.player[Projectile.owner].statLifeMax2)
 			{
 				for (int i = 0; i < 12; i++)
 				{
@@ -247,13 +249,14 @@ namespace StarlightRiver.Content.Items.Misc.SoilgunFiles
 				}
 
 				if (Main.myPlayer == Projectile.owner && !target.SpawnedFromStatue && target.lifeMax > 5 && target.type != NPCID.TargetDummy)
-					Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, Projectile.DirectionTo(Main.player[Projectile.owner].Center), ModContent.ProjectileType<SoilgunLifeSteal>(), 0, 0f, Projectile.owner, 2 + (int)(damageDone * 0.1f));
+					Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, Projectile.DirectionTo(Main.player[Projectile.owner].Center), ModContent.ProjectileType<SoilgunLifeSteal>(), 0, 0f, Projectile.owner, 1);
 			}
 		}
 
 		public override void Kill(int timeLeft)
 		{
 			SoundEngine.PlaySound(SoundID.Dig, Projectile.position);
+
 			for (int i = 0; i < 15; i++)
 			{
 				Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.CrimsonPlants, 0f, 0f, 25, default, Main.rand.NextFloat(0.8f, 1f));

--- a/Content/Items/Misc/Weapons.Earthduster.cs
+++ b/Content/Items/Misc/Weapons.Earthduster.cs
@@ -12,6 +12,8 @@ namespace StarlightRiver.Content.Items.Misc
 {
 	public class Earthduster : MultiAmmoWeapon
 	{
+		public override string Texture => AssetDirectory.MiscItem + Name;
+
 		public override List<AmmoStruct> ValidAmmos => new()
 		{
 			new AmmoStruct(ItemID.SandBlock, ModContent.ProjectileType<SoilgunSandSoil>(), 2),
@@ -25,8 +27,6 @@ namespace StarlightRiver.Content.Items.Misc
 			new AmmoStruct(ItemID.MudBlock, ModContent.ProjectileType<SoilgunMudSoil>(), 3),
 		};
 
-		public override string Texture => AssetDirectory.MiscItem + Name;
-
 		public override void SetStaticDefaults()
 		{
 			Tooltip.SetDefault("Hold <left> to fire a rapid stream of earth\nCan use many different blocks as ammo, each with unique effects\n33% chance to not consume ammo");
@@ -35,7 +35,7 @@ namespace StarlightRiver.Content.Items.Misc
 		public override void SafeSetDefaults()
 		{
 			Item.DamageType = DamageClass.Ranged;
-			Item.damage = 25;
+			Item.damage = 6;
 			Item.width = 70;
 			Item.height = 40;
 			Item.useAnimation = Item.useTime = 5;
@@ -54,10 +54,11 @@ namespace StarlightRiver.Content.Items.Misc
 
 		public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
 		{
-			Projectile proj = Projectile.NewProjectileDirect(source, position, velocity, ModContent.ProjectileType<EarthdusterHoldout>(), damage, knockback, player.whoAmI);
+			var proj = Projectile.NewProjectileDirect(source, position, velocity, ModContent.ProjectileType<EarthdusterHoldout>(), damage, knockback, player.whoAmI);
 
 			if (proj.ModProjectile is EarthdusterHoldout earthduster)
 				earthduster.SoilType = type;
+
 			return false;
 		}
 
@@ -206,7 +207,7 @@ namespace StarlightRiver.Content.Items.Misc
 						SoundEngine.PlaySound(SoundID.MaxMana with { Pitch = -0.5f }, Owner.Center);
 						if (Main.myPlayer == Projectile.owner)
 						{
-							Projectile proj = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), armPos, Projectile.velocity * 1.5f, ModContent.ProjectileType<EarthdusterRing>(), 0, 0f, Owner.whoAmI, 15f);
+							var proj = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), armPos, Projectile.velocity * 1.5f, ModContent.ProjectileType<EarthdusterRing>(), 0, 0f, Owner.whoAmI, 15f);
 
 							(proj.ModProjectile as EarthdusterRing).trailColorOutline = (GhostProj.ModProjectile as BaseSoilProjectile).RingOutsideColor;
 
@@ -318,12 +319,12 @@ namespace StarlightRiver.Content.Items.Misc
 			Texture2D glowTex = ModContent.Request<Texture2D>(Texture + "_Glow").Value;
 			Texture2D bloomTex = ModContent.Request<Texture2D>(AssetDirectory.Keys + "GlowAlpha").Value;
 
-			Vector2 offset = Vector2.Lerp(Vector2.Zero, Vector2.UnitY.RotatedBy(Projectile.rotation + (Owner.direction == -1 ? MathHelper.Pi : 0f)) * 13f, shots / (float)MAXSHOTS);
+			var offset = Vector2.Lerp(Vector2.Zero, Vector2.UnitY.RotatedBy(Projectile.rotation + (Owner.direction == -1 ? MathHelper.Pi : 0f)) * 13f, shots / (float)MAXSHOTS);
 			Main.spriteBatch.Draw(dirtTex, Projectile.Center + offset - Main.screenPosition, null, lightColor, Projectile.rotation, dirtTex.Size() / 2f, Projectile.scale, Owner.direction == -1 ? SpriteEffects.FlipVertically : 0f, 0f);
 
 			Main.spriteBatch.Draw(tex, Projectile.Center - Main.screenPosition, null, lightColor, Projectile.rotation, tex.Size() / 2f, Projectile.scale, Owner.direction == -1 ? SpriteEffects.FlipVertically : 0f, 0f);
 
-			Color color = Color.Lerp(Color.Transparent, (GhostProj.ModProjectile as BaseSoilProjectile).RingInsideColor, shots / (float)MAXSHOTS);
+			var color = Color.Lerp(Color.Transparent, (GhostProj.ModProjectile as BaseSoilProjectile).RingInsideColor, shots / (float)MAXSHOTS);
 			//if (reloading)
 			//color = Color.Lerp(GetRingInsideColor(), Color.Transparent, ShootDelay / 90f);
 
@@ -477,7 +478,7 @@ namespace StarlightRiver.Content.Items.Misc
 			for (int i = 0; i < 33; i++) //TODO: Cache offsets, to improve performance
 			{
 				double rad = i / 32f * 6.28f;
-				Vector2 offset = new Vector2((float)Math.Sin(rad) * 0.3f, (float)Math.Cos(rad));
+				var offset = new Vector2((float)Math.Sin(rad) * 0.3f, (float)Math.Cos(rad));
 				offset *= radius;
 				offset = offset.RotatedBy(Projectile.velocity.ToRotation());
 				cache.Add(Projectile.Center + offset);
@@ -496,7 +497,7 @@ namespace StarlightRiver.Content.Items.Misc
 
 			trail2 ??= new Trail(Main.instance.GraphicsDevice, 33, new TriangularTip(1), factor => 10 * (1 - Progress), factor => trailColor);
 			float nextplace = 33f / 32f;
-			Vector2 offset = new Vector2((float)Math.Sin(nextplace), (float)Math.Cos(nextplace));
+			var offset = new Vector2((float)Math.Sin(nextplace), (float)Math.Cos(nextplace));
 			offset *= Radius;
 
 			trail.Positions = cache.ToArray();
@@ -510,9 +511,9 @@ namespace StarlightRiver.Content.Items.Misc
 		{
 			Effect effect = Terraria.Graphics.Effects.Filters.Scene["OrbitalStrikeTrail"].GetShader().Shader;
 
-			Matrix world = Matrix.CreateTranslation(-Main.screenPosition.Vec3());
+			var world = Matrix.CreateTranslation(-Main.screenPosition.Vec3());
 			Matrix view = Main.GameViewMatrix.TransformationMatrix;
-			Matrix projection = Matrix.CreateOrthographicOffCenter(0, Main.screenWidth, Main.screenHeight, 0, -1, 1);
+			var projection = Matrix.CreateOrthographicOffCenter(0, Main.screenWidth, Main.screenHeight, 0, -1, 1);
 
 			effect.Parameters["transformMatrix"].SetValue(world * view * projection);
 			effect.Parameters["sampleTexture"].SetValue(ModContent.Request<Texture2D>("StarlightRiver/Assets/GlowTrail").Value);

--- a/Content/Items/Permafrost/Weapons.Tentalance.cs
+++ b/Content/Items/Permafrost/Weapons.Tentalance.cs
@@ -22,7 +22,7 @@ namespace StarlightRiver.Content.Items.Permafrost
 			Item.width = 54;
 			Item.height = 54;
 			Item.DamageType = DamageClass.Melee;
-			Item.damage = 16;
+			Item.damage = 18;
 			Item.useTime = 30;
 			Item.useAnimation = 30;
 			Item.useStyle = Terraria.ID.ItemUseStyleID.Shoot;
@@ -173,6 +173,11 @@ namespace StarlightRiver.Content.Items.Permafrost
 
 			ManageCaches();
 			ManageTrail();
+		}
+
+		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
+		{
+			Projectile.damage /= 2;
 		}
 
 		public Color GetColor(float off)

--- a/Content/Items/UndergroundTemple/Accessories.TempleLens.cs
+++ b/Content/Items/UndergroundTemple/Accessories.TempleLens.cs
@@ -8,7 +8,7 @@ namespace StarlightRiver.Content.Items.UndergroundTemple
 	{
 		public override string Texture => AssetDirectory.CaveTempleItem + Name;
 
-		public TempleLens() : base("Ancient Lens", "Critical strikes cause enemies around the struck enemy to glow, revealing other enemies\n+3% critical strike chance \n+10% critical strike damage") { }
+		public TempleLens() : base("Ancient Lens", "Critical strikes cause enemies around the struck enemy to glow, revealing other enemies\n+2% critical strike chance \n+15% critical strike damage") { }
 
 		public override void SafeSetDefaults()
 		{
@@ -17,8 +17,8 @@ namespace StarlightRiver.Content.Items.UndergroundTemple
 
 		public override void SafeUpdateEquip(Player Player)
 		{
-			Player.GetCritChance(DamageClass.Generic) += 3;
-			Player.GetModPlayer<CritMultiPlayer>().AllCritMult += 0.1f;
+			Player.GetCritChance(DamageClass.Generic) += 2;
+			Player.GetModPlayer<CritMultiPlayer>().AllCritMult += 0.15f;
 		}
 
 		public override void Load()

--- a/Content/Items/UndergroundTemple/Accessories.TempleLensUpgrade.cs
+++ b/Content/Items/UndergroundTemple/Accessories.TempleLensUpgrade.cs
@@ -12,7 +12,7 @@ namespace StarlightRiver.Content.Items.UndergroundTemple
 	{
 		public override string Texture => AssetDirectory.CaveTempleItem + Name;
 
-		public TempleLensUpgrade() : base("Truestrike Lens", "Critical strikes expose enemies near the struck enemy\nExposed enemies have 20% increased Exposure on first hit\n+4% critical strike chance\n+10% critical strike damage") { }
+		public TempleLensUpgrade() : base("Truestrike Lens", "Critical strikes expose enemies near the struck enemy\nExposed enemies have 20% increased Exposure on first hit\n+2% critical strike chance\n+20% critical strike damage") { }
 
 		public override void SafeSetDefaults()
 		{
@@ -21,8 +21,8 @@ namespace StarlightRiver.Content.Items.UndergroundTemple
 
 		public override void SafeUpdateEquip(Player Player)
 		{
-			Player.GetCritChance(DamageClass.Generic) += 4;
-			Player.GetModPlayer<CritMultiPlayer>().AllCritMult += 0.1f;
+			Player.GetCritChance(DamageClass.Generic) += 2;
+			Player.GetModPlayer<CritMultiPlayer>().AllCritMult += 0.2f;
 		}
 
 		public override void Load()

--- a/Content/Items/Vitric/Armors.VitricArmor.cs
+++ b/Content/Items/Vitric/Armors.VitricArmor.cs
@@ -198,7 +198,7 @@ namespace StarlightRiver.Content.Items.Vitric
 
 		public override void UpdateEquip(Player Player)
 		{
-			Player.GetHandler().StaminaRegenRate += 0.1f;
+			Player.GetHandler().StaminaRegenRate += 2;
 		}
 
 		public override void AddRecipes()

--- a/Content/Items/Vitric/Armors.VitricArmor.cs
+++ b/Content/Items/Vitric/Armors.VitricArmor.cs
@@ -184,7 +184,7 @@ namespace StarlightRiver.Content.Items.Vitric
 		public override void SetStaticDefaults()
 		{
 			DisplayName.SetDefault("Vitric Greaves");
-			Tooltip.SetDefault("Slightly improved starlight regeneration");
+			Tooltip.SetDefault("+ 2 Starlight regeneration");
 		}
 
 		public override void SetDefaults()

--- a/Content/Prefixes/Accessory/StaminaPrefixes.cs
+++ b/Content/Prefixes/Accessory/StaminaPrefixes.cs
@@ -51,21 +51,21 @@ namespace StarlightRiver.Content.Prefixes.Accessory
 
 	internal class StaminaPrefix1 : StaminaPrefix
 	{
-		public StaminaPrefix1() : base(1, "Sparkling", "+1 starlight regeneration") { }
+		public StaminaPrefix1() : base(1, "Sparkling", "+1 Starlight regeneration") { }
 	}
 
 	internal class StaminaPrefix2 : StaminaPrefix
 	{
-		public StaminaPrefix2() : base(2, "Shining", "+2 starlight regeneration") { }
+		public StaminaPrefix2() : base(2, "Shining", "+2 Starlight regeneration") { }
 	}
 
 	internal class StaminaPrefix3 : StaminaPrefix
 	{
-		public StaminaPrefix3() : base(3, "Glowing", "+3 starlight regeneration") { }
+		public StaminaPrefix3() : base(3, "Glowing", "+3 Starlight regeneration") { }
 	}
 
 	internal class StaminaPrefix4 : StaminaPrefix
 	{
-		public StaminaPrefix4() : base(4, "Radiant", "+4 starlight regeneration") { }
+		public StaminaPrefix4() : base(4, "Radiant", "+4 Starlight regeneration") { }
 	}
 }

--- a/Content/Prefixes/Accessory/StaminaPrefixes.cs
+++ b/Content/Prefixes/Accessory/StaminaPrefixes.cs
@@ -51,21 +51,21 @@ namespace StarlightRiver.Content.Prefixes.Accessory
 
 	internal class StaminaPrefix1 : StaminaPrefix
 	{
-		public StaminaPrefix1() : base(2, "Sparkling", "+2 starlight regeneration") { }
+		public StaminaPrefix1() : base(1, "Sparkling", "+1 starlight regeneration") { }
 	}
 
 	internal class StaminaPrefix2 : StaminaPrefix
 	{
-		public StaminaPrefix2() : base(4, "Shining", "+4 starlight regeneration") { }
+		public StaminaPrefix2() : base(2, "Shining", "+2 starlight regeneration") { }
 	}
 
 	internal class StaminaPrefix3 : StaminaPrefix
 	{
-		public StaminaPrefix3() : base(6, "Glowing", "+6 starlight regeneration") { }
+		public StaminaPrefix3() : base(3, "Glowing", "+3 starlight regeneration") { }
 	}
 
 	internal class StaminaPrefix4 : StaminaPrefix
 	{
-		public StaminaPrefix4() : base(8, "Radiant", "+8 starlight regeneration") { }
+		public StaminaPrefix4() : base(4, "Radiant", "+4 starlight regeneration") { }
 	}
 }

--- a/Core/Systems/BarrierSystem/BarrierPlayer.cs
+++ b/Core/Systems/BarrierSystem/BarrierPlayer.cs
@@ -18,10 +18,10 @@ namespace StarlightRiver.Core.Systems.BarrierSystem
 		public int overchargeDrainRate = 60;
 
 		public int timeSinceLastHit = 0;
-		public int rechargeDelay = 480;
-		public int rechargeRate = 4;
+		public int rechargeDelay = 300;
+		public int rechargeRate = 6;
 
-		public float barrierDamageReduction = 0.3f;
+		public float barrierDamageReduction = 0.5f;
 
 		public float rechargeAnimationTimer;
 		public Item barrierDyeItem;
@@ -220,10 +220,10 @@ namespace StarlightRiver.Core.Systems.BarrierSystem
 			dontDrainOvercharge = false;
 			overchargeDrainRate = 60;
 
-			rechargeDelay = 480;
-			rechargeRate = 4;
+			rechargeDelay = 300;
+			rechargeRate = 6;
 
-			barrierDamageReduction = Main.expertMode ? 0.4f : 0.3f;
+			barrierDamageReduction = 0.5f;
 
 			if (Dye is null)
 			{

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -2907,6 +2907,28 @@ Mods: {
 					100% increased sentry placement speed
 					'''
 			}
+
+			ArtilleryLicense: {
+				DisplayName: Artillery License
+				Tooltip:
+					'''
+					Increases your max number of sentries by 1
+					`Totally not forged`
+					'''
+			}
+
+			DefenseSystem: {
+				DisplayName: Arms Dealer's Defense System
+				Tooltip:
+					'''
+					Summons a gun-toting turret
+					Right click to cycle between different guns
+					[i/s1:95] Modest damage with good range
+					[i/s1:964] Great damage with short range
+					[i/s1:98] Light damage with great fire rate
+
+					'''
+			}
 		}
 
 		Projectiles: {
@@ -3183,6 +3205,9 @@ Mods: {
 			VitricOreFloatDummy.DisplayName: ""
 			VitricSmallDummy.DisplayName: ""
 			VitricBannerDummy.DisplayName: ""
+			MinigunTurret.DisplayName: Gun turret
+			PistolTurret.DisplayName: Gun turret
+			ShotgunTurret.DisplayName: Gun turret
 		}
 
 		Tiles: {

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -42,3 +42,20 @@
 - The boss rush will now save your scores across sessions
 - Updated boss rush damage resistance calculations to discourage strategies related to stalling
 - Updated the boss rush GUI
+
+## Balance
+- Starlight regeneration has recieved a large overhaul
+- Each point of starlight regeneration now grants 0.05 starlight per second
+- Base starlight regeneration is now 5 (0.25 per second)
+- Starlight regeneration penalth from movement significantly reduced
+- Starlight regeneration cooldown after using an ability significantly reduced
+- Many pieces of equipment with starlight regeneration have been updated to reflect new values
+- Barrier base values have been buffed
+- Base resistance 40%/30% (expert+/normal) => 50% (always)
+- Base recharge delay 8s => 5s
+- Base recharge rate 4 => 6
+- Tentalance damage increased (16 => 18)
+- Tentalance now has 50% damage falloff per target pierced
+- Ancient Lens critical strike chance decreased (3% => 2%) critical strike damage increased (10% => 15%)
+- Truestrike Lens critical strike chance decreased (4% => 2%) critical strike damage increased (10% => 20%)
+

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -61,3 +61,4 @@
 - Soilgun damage reduced (16 => 4)
 - Earthduster damage reduced (25 => 6)
 - Soilgun/Earthduster crimsand nerfed (healing chance 33% => 20%) (healing 2 + 10% damage => 1)
+- Auroracle's water will now deal a small amount of damage when you fall in to alert you of the danger

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -58,4 +58,6 @@
 - Tentalance now has 50% damage falloff per target pierced
 - Ancient Lens critical strike chance decreased (3% => 2%) critical strike damage increased (10% => 15%)
 - Truestrike Lens critical strike chance decreased (4% => 2%) critical strike damage increased (10% => 20%)
-
+- Soilgun damage reduced (16 => 4)
+- Earthduster damage reduced (25 => 6)
+- Soilgun/Earthduster crimsand nerfed (healing chance 33% => 20%) (healing 2 + 10% damage => 1)


### PR DESCRIPTION
This PR introduces various balance changes to the game. These changes can also be found in PATCH_NOTES.txt

## Balance
- Starlight regeneration has recieved a large overhaul
- Each point of starlight regeneration now grants 0.05 starlight per second
- Base starlight regeneration is now 5 (0.25 per second)
- Starlight regeneration penalth from movement significantly reduced
- Starlight regeneration cooldown after using an ability significantly reduced
- Many pieces of equipment with starlight regeneration have been updated to reflect new values
- Barrier base values have been buffed
- Base resistance 40%/30% (expert+/normal) => 50% (always)
- Base recharge delay 8s => 5s
- Base recharge rate 4 => 6
- Tentalance damage increased (16 => 18)
- Tentalance now has 50% damage falloff per target pierced
- Ancient Lens critical strike chance decreased (3% => 2%) critical strike damage increased (10% => 15%)
- Truestrike Lens critical strike chance decreased (4% => 2%) critical strike damage increased (10% => 20%)
- Soilgun damage reduced (16 => 4)
- Earthduster damage reduced (25 => 6)
- Soilgun/Earthduster crimsand nerfed (healing chance 33% => 20%) (healing 2 + 10% damage => 1)
- Auroracle's water will now deal a small amount of damage when you fall in to alert you of the danger