### PR TITLE
add Localization/en-US.hjson to gitignore to cutdown on commit merge conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,4 @@ FETCH_HEAD
 *.pack
 refs/remotes/origin/ArmorEnchantAndBags
 FETCH_HEAD
+/Localization/en-US.hjson


### PR DESCRIPTION
Should reduce the amount of merge conflicts from it getting generated every time

VS seemed to be acting weird about this getting removed and not treating it like it is but I'm nearly 100% confident that the gitignore itself is correct and its just VS being VS