### PR TITLE
Unload null coalesce

### DIFF
--- a/Content/Bestiary/SLRSpawnConditions.cs
+++ b/Content/Bestiary/SLRSpawnConditions.cs
@@ -10,9 +10,9 @@
 
 		public static void Unload()
 		{
-			VitricDesert = null;
-			AuroraSquid = null;
-			Moonstone = null;
+			VitricDesert ??= null;
+			AuroraSquid ??= null;
+			Moonstone ??= null;
 		}
 	}
 }

--- a/Content/CustomHooks/Visuals.CharacterSelectAddons.cs
+++ b/Content/CustomHooks/Visuals.CharacterSelectAddons.cs
@@ -34,7 +34,7 @@ namespace StarlightRiver.Content.CustomHooks
 
 		public override void Unload()
 		{
-			sparkles = null;
+			sparkles ??= null;
 		}
 
 		private static void updateSparkles(Particle particle)

--- a/Content/CustomHooks/Visuals.VitricBackground.cs
+++ b/Content/CustomHooks/Visuals.VitricBackground.cs
@@ -27,8 +27,8 @@ namespace StarlightRiver.Content.CustomHooks
 
 		public override void Unload()
 		{
-			ForegroundParticles = null;
-			BackgroundParticles = null;
+			ForegroundParticles ??= null;
+			BackgroundParticles ??= null;
 		}
 
 		private void ForceDrawBlack(On_Main.orig_DrawBlack orig, Main self, bool force)

--- a/Content/CustomHooks/Visuals.WaterAddonHandler.cs
+++ b/Content/CustomHooks/Visuals.WaterAddonHandler.cs
@@ -29,10 +29,7 @@ namespace StarlightRiver.Content.CustomHooks
 			WaterAddonHandler.addons.Add(this);
 		}
 
-		public void Unload()
-		{
-			WaterAddonHandler.addons.Remove(this);
-		}
+		public void Unload() { }
 	}
 
 	class WaterAddonHandler : HookGroup
@@ -58,8 +55,8 @@ namespace StarlightRiver.Content.CustomHooks
 
 		public override void Unload()
 		{
-			addons = null;
-			activeAddon = null;
+			addons ??= null;
+			activeAddon ??= null;
 		}
 
 		private void SwapBlockTexture(ILContext il)

--- a/Content/Items/BaseTypes/CursedAccessory.cs
+++ b/Content/Items/BaseTypes/CursedAccessory.cs
@@ -31,8 +31,8 @@ namespace StarlightRiver.Content.Items.BaseTypes
 
 		public static void UnloadSystem()
 		{
-			CursedSystem = null;
-			ShardsSystem = null;
+			CursedSystem ??= null;
+			ShardsSystem ??= null;
 		}
 
 		protected CursedAccessory(Texture2D glow) : base("Unnamed Cursed Accessory", "You forgot to give this a display name dingus!")

--- a/Content/Lavas/LavaLoader.cs
+++ b/Content/Lavas/LavaLoader.cs
@@ -36,8 +36,8 @@ namespace StarlightRiver.Content.Lavas
 			Terraria.GameContent.Liquid.IL_LiquidRenderer.InternalPrepareDraw -= SwapLavaDrawEffects;
 			//IL.Terraria.Main.DrawTiles -= DrawSpecialLavaBlock;
 
-			lavas = null;
-			ActiveStyle = null;
+			lavas ??= null;
+			ActiveStyle ??= null;
 		}
 
 		public float Priority => 1;

--- a/Content/NPCs/Actors/StarlightWaterActor.cs
+++ b/Content/NPCs/Actors/StarlightWaterActor.cs
@@ -327,7 +327,7 @@ namespace StarlightRiver.Content.NPCs.Actors
 		public void Unload()
 		{
 			StarlightPlayer.ResetEffectsEvent -= ResetInventoryGlow;
-			StarlightWaterConversion = null;
+			StarlightWaterConversion ??= null;
 		}
 	}
 

--- a/Content/Physics/VerletChain.cs
+++ b/Content/Physics/VerletChain.cs
@@ -21,8 +21,8 @@ namespace StarlightRiver.Content.Physics
 
 		public void Unload()
 		{
-			target = null;
-			toDraw = null;
+			target ??= null;
+			toDraw ??= null;
 		}
 
 		private void DrawVerletBanners(On_Main.orig_DrawProjectiles orig, Main self)

--- a/Core/Loaders/ArmorEnchantLoader.cs
+++ b/Core/Loaders/ArmorEnchantLoader.cs
@@ -27,7 +27,7 @@ namespace StarlightRiver.Core.Loaders
 
 		public void Unload()
 		{
-			Enchantments = null;
+			Enchantments ??= null;
 		}
 	}
 }

--- a/Core/Loaders/DyeLoader.cs
+++ b/Core/Loaders/DyeLoader.cs
@@ -17,9 +17,6 @@ namespace StarlightRiver.Core.Loaders
 			GameShaders.Armor.BindShader(ModContent.ItemType<RainbowCycleDye2>(), new ArmorShaderData(new Ref<Effect>(Filters.Scene["RainbowArmor2"].GetShader().Shader), "BasicPass"));
 		}
 
-		public void Unload()
-		{
-
-		}
+		public void Unload() { }
 	}
 }

--- a/Core/Loaders/TileDrawOverLoader.cs
+++ b/Core/Loaders/TileDrawOverLoader.cs
@@ -28,8 +28,8 @@ namespace StarlightRiver.Core.Loaders
 			On_Main.DrawProjectiles -= Main_DrawProjectiles;
 			On_Main.Update -= Main_Update;
 
-			projTarget = null;
-			tileTarget = null;
+			projTarget ??= null;
+			tileTarget ??= null;
 		}
 
 		private void Main_DrawProjectiles(On_Main.orig_DrawProjectiles orig, Main self)

--- a/Core/PlayerTicker.cs
+++ b/Core/PlayerTicker.cs
@@ -15,7 +15,7 @@
 
 		public void Unload()
 		{
-			StarlightPlayer.spawners.Remove(this);
+			StarlightPlayer.spawners?.Remove(this);
 		}
 
 		public virtual void Tick(Player Player) { }

--- a/Core/Systems/CutawaySystem/CutawayHook.cs
+++ b/Core/Systems/CutawaySystem/CutawayHook.cs
@@ -27,8 +27,8 @@ namespace StarlightRiver.Core.Systems.CutawaySystem
 
 		public override void Unload()
 		{
-			cutaways = null;
-			cutawayTarget = null;
+			cutaways ??= null;
+			cutawayTarget ??= null;
 		}
 
 		private void ClearCutaways(On_WorldGen.orig_SaveAndQuit orig, Action callback)

--- a/Core/Systems/ForegroundSystem/ForegroundSystem.cs
+++ b/Core/Systems/ForegroundSystem/ForegroundSystem.cs
@@ -33,8 +33,8 @@ namespace StarlightRiver.Core.Systems.ForegroundSystem
 
 		public void Unload()
 		{
-			Foregrounds.ForEach(t => t.Unload());
-			Foregrounds = null;
+			Foregrounds?.ForEach(t => t.Unload());
+			Foregrounds ??= null;
 		}
 	}
 }

--- a/Core/Systems/MetaballSystem/MetaballSystem.cs
+++ b/Core/Systems/MetaballSystem/MetaballSystem.cs
@@ -28,7 +28,7 @@ namespace StarlightRiver.Core.Systems.MetaballSystem
 			On_Main.CheckMonoliths -= BuildTargets;
 
 			actorsSem.WaitOne();
-			actors = null;
+			actors ??= null;
 			actorsSem.Release();
 		}
 

--- a/Core/Systems/PersistentDataSystem/PersistentDataStore.cs
+++ b/Core/Systems/PersistentDataSystem/PersistentDataStore.cs
@@ -21,10 +21,7 @@ namespace StarlightRiver.Core.Systems.PersistentDataSystem
 			LoadFromFile(currentPath);
 		}
 
-		public void Unload()
-		{
-
-		}
+		public void Unload() { }
 
 		/// <summary>
 		/// Forces a save of this data.

--- a/StarlightRiver.cs
+++ b/StarlightRiver.cs
@@ -120,8 +120,8 @@ namespace StarlightRiver
 
 			if (!Main.dedServ)
 			{
-				Instance = null;
-				AbilityKeys.Unload();
+				Instance ??= null;
+				AbilityKeys?.Unload();
 
 				SLRSpawnConditions.Unload();
 			}


### PR DESCRIPTION
This PR adds some safety checks to various unloading methods to ensure we dont try to unload already null data, causing a nasty crash.