### PR TITLE
Mp cooking

### DIFF
--- a/Content/GUI/CookingUI.cs
+++ b/Content/GUI/CookingUI.cs
@@ -1,11 +1,13 @@
 ﻿using StarlightRiver.Content.Items.Food;
 using StarlightRiver.Content.Items.Food.Special;
+using StarlightRiver.Content.Items.Utility;
 using StarlightRiver.Core.Loaders.UILoading;
 using StarlightRiver.Helpers;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
+using Terraria.GameInput;
 using Terraria.ID;
 using Terraria.UI;
 using static Terraria.ModLoader.ModContent;
@@ -32,6 +34,8 @@ namespace StarlightRiver.Content.GUI
 
 		public static Vector2 Basepos = new(Main.screenWidth / 2 - 173, Main.screenHeight / 2 - 122);
 
+		public static Vector2 prepStationPos = Vector2.Zero;
+
 		public override bool Visible => visible;
 
 		public override int InsertionIndex(List<GameInterfaceLayer> layers)
@@ -51,8 +55,12 @@ namespace StarlightRiver.Content.GUI
 
 		public override void SafeUpdate(GameTime gameTime)
 		{
-			if (!Main.playerInventory)
+			if (!Main.playerInventory || prepStationPos.DistanceSQ(Main.LocalPlayer.position) > 60000)
+			{
+				ExtractItems();
 				visible = false;
+			}
+
 
 			if (TopBar.IsMouseHovering && Main.mouseLeft)
 			{
@@ -229,9 +237,20 @@ namespace StarlightRiver.Content.GUI
 
 		private void Exit()
 		{
+			ExtractItems();
 			visible = false;
+			ChefBagUI.visible = false;
 			Main.playerInventory = false;
 			Terraria.Audio.SoundEngine.PlaySound(SoundID.MenuClose);
+		}
+
+		public void ExtractItems()
+		{
+			MainSlot.ExtractItemToInventory();
+			SideSlot0.ExtractItemToInventory();
+			SideSlot1.ExtractItemToInventory();
+			SeasonSlot.ExtractItemToInventory();
+
 		}
 	}
 
@@ -248,7 +267,23 @@ namespace StarlightRiver.Content.GUI
 		public override void Draw(SpriteBatch spriteBatch)
 		{
 			if (IsMouseHovering)
+			{
 				Main.LocalPlayer.mouseInterface = true;
+
+				if (!Item.IsAir)
+				{
+					Main.LocalPlayer.mouseInterface = true;
+					Main.HoverItem = Item.Clone();
+					Main.hoverItemName = "a"; //required but the value doesn't matter for having it show up
+
+					if (Main.keyState.PressingShift() && (ChefBagUI.visible || Helper.getFreeInventorySlot(Main.LocalPlayer) != -1))
+						Main.cursorOverride = 7;
+				}
+				else
+				{
+					Main.hoverItemName = "Place [c/" + Ingredient.GetDescriptionColor(Type).Hex3() + ":" + Ingredient.GetDescription(Type) + "] here";
+				}
+			}
 
 			Texture2D tex = Request<Texture2D>("StarlightRiver/Assets/GUI/CookSlotY").Value;
 			switch (Type)
@@ -267,17 +302,22 @@ namespace StarlightRiver.Content.GUI
 
 				if (Item.stack > 1)
 					Utils.DrawBorderString(spriteBatch, Item.stack.ToString(), GetDimensions().Position() + Vector2.One * 32, Color.White, 0.75f);
-
-				if (IsMouseHovering)
-				{
-					Main.LocalPlayer.mouseInterface = true;
-					Main.HoverItem = Item.Clone();
-					Main.hoverItemName = "a";
-				}
 			}
+
+
 		}
 
 		public override void SafeClick(UIMouseEvent evt)
+		{
+			Main.isMouseLeftConsumedByUI = true;
+
+			if (PlayerInput.Triggers.Current.SmartSelect)
+				ExtractItemToInventory();
+			else
+				LeftClick();
+		}
+
+		private void LeftClick()
 		{
 			Player Player = Main.LocalPlayer;
 
@@ -329,8 +369,64 @@ namespace StarlightRiver.Content.GUI
 					Terraria.Audio.SoundEngine.PlaySound(SoundID.Grab);
 				}
 			}
+		}
 
-			Main.isMouseLeftConsumedByUI = true;
+		public override void SafeRightClick(UIMouseEvent evt)
+		{
+			if (Main.mouseItem.IsAir)
+			{
+				var item = new Item();
+				item.SetDefaults(Item.type);
+				item.stack = 1;
+
+				Main.mouseItem = item;
+
+				Item.stack--;
+
+				if (Item.stack == 0)
+					Item.TurnToAir();
+
+				Terraria.Audio.SoundEngine.PlaySound(SoundID.MenuTick);
+			}
+			else if (Main.mouseItem.type == Item.type && Main.mouseItem.stack < Main.mouseItem.maxStack)
+			{
+				Main.mouseItem.stack++;
+				Item.stack--;
+
+				if (Item.stack == 0)
+					Item.TurnToAir();
+
+				Terraria.Audio.SoundEngine.PlaySound(SoundID.MenuTick);
+			}
+		}
+
+		public void ExtractItemToInventory()
+		{
+			//extract items out of the UI and place into chef bag / inventory
+			//use for shift left clicking and exiting the UI
+
+			Item bag = Main.LocalPlayer.inventory.FirstOrDefault(n => n.type == ItemType<ChefBag>());
+
+			if (bag != null)
+			{
+				if ((bag.ModItem as ChefBag).InsertItem(Item.Clone()))
+				{
+					Item.TurnToAir();
+					Terraria.Audio.SoundEngine.PlaySound(SoundID.Grab);
+					return;
+				}
+			}
+
+			//attempt to quick place into your inventory if no chef bag or invalid to place there
+			int invSlotCount = Helper.getFreeInventorySlot(Main.LocalPlayer);
+
+			if (!Item.IsAir && invSlotCount != -1)
+			{
+				Main.LocalPlayer.GetItem(Main.myPlayer, Item.Clone(), GetItemSettings.InventoryUIToInventorySettings);
+				Item.TurnToAir();
+				Terraria.Audio.SoundEngine.PlaySound(SoundID.Grab);
+			}
+
 		}
 
 		public override void SafeUpdate(GameTime gameTime)

--- a/Content/GUI/CookingUI.cs
+++ b/Content/GUI/CookingUI.cs
@@ -61,7 +61,6 @@ namespace StarlightRiver.Content.GUI
 				visible = false;
 			}
 
-
 			if (TopBar.IsMouseHovering && Main.mouseLeft)
 			{
 				if (!Moving)
@@ -250,7 +249,6 @@ namespace StarlightRiver.Content.GUI
 			SideSlot0.ExtractItemToInventory();
 			SideSlot1.ExtractItemToInventory();
 			SeasonSlot.ExtractItemToInventory();
-
 		}
 	}
 
@@ -303,8 +301,6 @@ namespace StarlightRiver.Content.GUI
 				if (Item.stack > 1)
 					Utils.DrawBorderString(spriteBatch, Item.stack.ToString(), GetDimensions().Position() + Vector2.One * 32, Color.White, 0.75f);
 			}
-
-
 		}
 
 		public override void SafeClick(UIMouseEvent evt)
@@ -426,7 +422,6 @@ namespace StarlightRiver.Content.GUI
 				Item.TurnToAir();
 				Terraria.Audio.SoundEngine.PlaySound(SoundID.Grab);
 			}
-
 		}
 
 		public override void SafeUpdate(GameTime gameTime)

--- a/Content/Items/Food/Ingredient.cs
+++ b/Content/Items/Food/Ingredient.cs
@@ -88,18 +88,9 @@ namespace StarlightRiver.Content.Items.Food
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips)
 		{
-			string description;
-			Color nameColor;
-			Color descriptionColor;
-
-			switch (ThisType)
-			{
-				case IngredientType.Main: description = "Main Course"; nameColor = new Color(255, 220, 140); descriptionColor = new Color(255, 220, 80); break;
-				case IngredientType.Side: description = "Side Dish"; nameColor = new Color(140, 255, 140); descriptionColor = new Color(80, 255, 80); break;
-				case IngredientType.Seasoning: description = "Seasonings"; nameColor = new Color(140, 200, 255); descriptionColor = new Color(80, 140, 255); break;
-				case IngredientType.Bonus: description = "Bonus Effects"; nameColor = new Color(255, 200, 200); descriptionColor = new Color(255, 140, 140); break;
-				default: description = "ERROR"; nameColor = Color.Black; descriptionColor = Color.Black; break;
-			}
+			string description = GetDescription(ThisType);
+			Color nameColor = GetColor(ThisType);
+			Color descriptionColor = GetDescriptionColor(ThisType);
 
 			foreach (TooltipLine line in tooltips)
 			{
@@ -127,14 +118,53 @@ namespace StarlightRiver.Content.Items.Food
 			}
 		}
 
+		public string GetDescription()
+		{
+			return GetDescription(ThisType);
+		}
+
 		public Color GetColor()
 		{
-			return ThisType switch
+			return GetColor(ThisType);
+		}
+
+		public Color GetDescriptionColor()
+		{
+			return GetDescriptionColor(ThisType);
+		}
+
+		public static string GetDescription(IngredientType type)
+		{
+			return type switch
+			{
+				IngredientType.Main => "Main Course",
+				IngredientType.Side => "Side Dish",
+				IngredientType.Seasoning => "Seasonings",
+				IngredientType.Bonus => "Bonus Effects",
+				_ => "ERROR",
+			};
+		}
+
+		public static Color GetColor(IngredientType type)
+		{
+			return type switch
 			{
 				IngredientType.Main => new Color(255, 220, 140),
 				IngredientType.Side => new Color(140, 255, 140),
 				IngredientType.Seasoning => new Color(140, 200, 255),
 				IngredientType.Bonus => new Color(255, 150, 150),
+				_ => Color.Black,
+			};
+		}
+
+		public static Color GetDescriptionColor(IngredientType type)
+		{
+			return type switch
+			{
+				IngredientType.Main => new Color(255, 220, 80),
+				IngredientType.Side => new Color(80, 255, 80),
+				IngredientType.Seasoning => new Color(80, 140, 255),
+				IngredientType.Bonus => new Color(255, 140, 140),
 				_ => Color.Black,
 			};
 		}

--- a/Content/Items/Food/Meal.cs
+++ b/Content/Items/Food/Meal.cs
@@ -1,5 +1,6 @@
 ﻿using StarlightRiver.Content.Buffs;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Terraria.GameContent;
 using Terraria.ID;
@@ -136,6 +137,33 @@ namespace StarlightRiver.Content.Items.Food
 			Fullness = tag.GetInt("Fullness");
 			BuffLengthMult = tag.GetFloat("FullnessMult");
 			DebuffLengthMult = tag.GetFloat("WellFedMult");
+		}
+
+		public override void NetSend(BinaryWriter writer)
+		{
+			writer.Write(Fullness);
+			writer.Write(BuffLengthMult);
+			writer.Write(DebuffLengthMult);
+
+			writer.Write(Ingredients.Count);
+			foreach (Item eachIngrediennt in Ingredients)
+				writer.Write(eachIngrediennt.type);
+		}
+
+		public override void NetReceive(BinaryReader reader)
+		{
+			Fullness = reader.ReadInt32();
+			BuffLengthMult = reader.ReadSingle();
+			DebuffLengthMult = reader.ReadSingle();
+
+			Ingredients = new List<Item>();
+			int ingredientCount = reader.ReadInt32();
+
+			for (int i = 0; i < ingredientCount; i++)
+			{
+				int ingredientType = reader.ReadInt32();
+				Ingredients.Add(new Item(ingredientType));
+			}
 		}
 	}
 }

--- a/Content/Tiles/Crafting/CookStation.cs
+++ b/Content/Tiles/Crafting/CookStation.cs
@@ -40,6 +40,7 @@ namespace StarlightRiver.Content.Tiles.Crafting
 
 			if (!CookingUI.visible)
 			{
+				CookingUI.prepStationPos = new Vector2(i * 16, j * 16);
 				CookingUI.visible = true;
 				Terraria.Audio.SoundEngine.PlaySound(SoundID.MenuOpen);
 

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -51,12 +51,15 @@
 - Fixed starwood armor and weapons in multiplayer
 - Fixed artifacts in multiplayer
 - Fixed most gores for multiplayer
+- Fixed cooking in multiplayer
 
 ## Misc
 - The boss rush now requires you to have defeated each boss atleast once to unlock
 - The boss rush will now save your scores across sessions
 - Updated boss rush damage resistance calculations to discourage strategies related to stalling
 - Updated the boss rush GUI
+- Added quick hotkeys to prep station and chef bag
+- Empty prep station slots now say which type of ingredient goes there
 
 ## Balance
 - Starlight regeneration has recieved a large overhaul


### PR DESCRIPTION
fixes cooking in multiplayer as well as adding a fewUI QoL enhancements and autoclosing the UI if the player wanders too far

Shift left click in cooking UI quick removes from the slot and places into the chefs bag or inventory if no chef bag
right clicking in cooking UI picks up one at a time

could implement other hotkeys but these were the ones that felt the most natural to me and others seemed kind of off or would be very difficult due to chests