### PR TITLE
Fix FaceSteak Drop

### DIFF
--- a/Content/Items/Food/Mains.EaterSteak.cs
+++ b/Content/Items/Food/Mains.EaterSteak.cs
@@ -26,7 +26,7 @@ namespace StarlightRiver.Content.Items.Food
 
 		private void LootEaterSteak(NPC NPC, NPCLoot npcloot)
 		{
-			if (NPC.type == NPCID.EaterofSouls)
+			if (NPC.type == NPCID.EaterofSouls || NPC.type == NPCID.Corruptor)
 				npcloot.Add(ItemDropRule.Common(ModContent.ItemType<EaterSteak>(), 8));
 		}
 	}

--- a/Content/Items/Food/Mains.FaceSteak.cs
+++ b/Content/Items/Food/Mains.FaceSteak.cs
@@ -28,7 +28,7 @@ namespace StarlightRiver.Content.Items.Food
 
 		private void LootFaceSteak(NPC NPC, NPCLoot npcloot)
 		{
-			if (NPC.type == NPCID.EaterofSouls)
+			if (NPC.type == NPCID.FaceMonster || NPC.type == NPCID.Herpling)
 				npcloot.Add(ItemDropRule.Common(ModContent.ItemType<FaceSteak>(), 8));
 		}
 	}


### PR DESCRIPTION
Fixes facesteak mistakenly dropping from eater of souls.
Also also allows eater steak and face steak to drop from the hardmode enemies corruptor and herpling.