### PR TITLE
Add FaceSteak Fix to patch notes

### DIFF
--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -27,3 +27,7 @@
 
 ## Fixes
 - Fixed glassweaver not being able to talk
+- Fixed Face Steak dropping from Eater of Souls (now drops from Face Monsters)
+
+## Tweaks
+- Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively


### PR DESCRIPTION
Part of the review from TripleFate on SuperAndyHero's PR "Fix FaceSteak Drop"
I assume 2.5.1 is the correct patch location.