### PR TITLE
fix for auto select

### DIFF
--- a/Content/CustomHooks/Mechanics.MouseSlotUseableInator.cs
+++ b/Content/CustomHooks/Mechanics.MouseSlotUseableInator.cs
@@ -12,7 +12,7 @@ namespace StarlightRiver.Content.CustomHooks
 			Terraria.UI.On_ItemSlot.LeftClick_ItemArray_int_int += LockMouseToSpecialItem;
 			Terraria.UI.On_ItemSlot.Draw_SpriteBatch_ItemArray_int_int_Vector2_Color += DrawSpecial;
 
-			IL_Player.ScrollHotbar += AllowBigScrolling;
+			//IL_Player.ScrollHotbar += AllowBigScrolling; disabled since it appears to do nothing currently and breaks auto-select
 			//IL_Player.Update += AllowBigHotkeying; PORTTODO: Fix IL, never mind this is unused for now. fix later if we actually use it!
 		}
 

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -3,6 +3,7 @@
 ## Fixes
 - Fixed Face Steak dropping from Eater of Souls (now drops from Face Monsters)
 - Fixed amulet of the bloodless warrior making you appear dead in multiplayer
+- Fixed auto-select being prevented from placing torches and throwing glowsticks
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively


### PR DESCRIPTION
This fixes the auto-select issue reported #665.
Completely disables the broken IL edit in question since it has no use as far as I can tell.