### PR TITLE
Mp item fixes

### DIFF
--- a/Content/Items/ArmsDealer/Weapons.DefenseSystem.cs
+++ b/Content/Items/ArmsDealer/Weapons.DefenseSystem.cs
@@ -49,8 +49,8 @@ namespace StarlightRiver.Content.Items.ArmsDealer
 			Item.height = 32;
 			Item.value = Item.buyPrice(gold: 30);
 			Item.rare = ItemRarityID.Green;
-			Item.useTime = 10;
-			Item.useAnimation = 10;
+			Item.useTime = 30;
+			Item.useAnimation = 30;
 			Item.useStyle = ItemUseStyleID.Swing;
 			Item.DamageType = DamageClass.Summon;
 			Item.damage = 12;

--- a/Content/Items/ArmsDealer/Weapons.DefenseSystem.cs
+++ b/Content/Items/ArmsDealer/Weapons.DefenseSystem.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using StarlightRiver.Content.CustomHooks;
+using System.Collections.Generic;
+using System.IO;
 using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -60,6 +62,16 @@ namespace StarlightRiver.Content.Items.ArmsDealer
 			Item.sentry = true;
 			Item.mana = 20;
 			Item.noMelee = true;
+		}
+
+		public override void NetSend(BinaryWriter writer)
+		{
+			writer.Write(dealerName);
+		}
+
+		public override void NetReceive(BinaryReader reader)
+		{
+			dealerName = reader.ReadString();
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips)
@@ -130,6 +142,14 @@ namespace StarlightRiver.Content.Items.ArmsDealer
 		/// <param name="spriteBatch"></param>
 		private void DrawRadial(Player player, SpriteBatch spriteBatch)
 		{
+			// Only draw radial menu for player wielding this 
+			if (player.whoAmI != Main.myPlayer)
+				return;
+
+			// Don't draw radial menu for render target
+			if (!PlayerTarget.canUseTarget)
+				return;
+
 			// Get the held instance, if it exists
 			var held = player.HeldItem.ModItem as DefenseSystem;
 

--- a/Content/Items/ArmsDealer/Weapons.DefenseSystem.cs
+++ b/Content/Items/ArmsDealer/Weapons.DefenseSystem.cs
@@ -374,7 +374,13 @@ namespace StarlightRiver.Content.Items.ArmsDealer
 
 		public override void Fire(Vector2 target)
 		{
-			Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center + Vector2.UnitY * -10, target * 14, ProjectileID.Bullet, 29, 1, Projectile.owner);
+			if (Main.myPlayer == Owner.whoAmI)
+			{
+				int projId = Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center + Vector2.UnitY * -10, target * 14, ProjectileID.Bullet, 29, 1, Projectile.owner);
+				Projectile bullet = Main.projectile[projId];
+				bullet.DamageType = DamageClass.Summon; //not synced but hopefully doesn't matter? otherwise we need some other solution
+			}
+
 			SoundEngine.PlaySound(SoundID.Item11, Projectile.Center);
 		}
 	}
@@ -388,9 +394,14 @@ namespace StarlightRiver.Content.Items.ArmsDealer
 
 		public override void Fire(Vector2 target)
 		{
-			for (int k = 0; k < 6; k++)
+			if (Main.myPlayer == Owner.whoAmI)
 			{
-				Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center + Vector2.UnitY * -10, target.RotatedByRandom(0.3f) * Main.rand.NextFloat(6, 8), ProjectileID.Bullet, 11, 1, Projectile.owner);
+				for (int k = 0; k < 6; k++)
+				{
+					int projId = Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center + Vector2.UnitY * -10, target.RotatedByRandom(0.3f) * Main.rand.NextFloat(6, 8), ProjectileID.Bullet, 11, 1, Projectile.owner);
+					Projectile bullet = Main.projectile[projId];
+					bullet.DamageType = DamageClass.Summon; //not synced but hopefully doesn't matter? otherwise we need some other solution
+				}
 			}
 
 			SoundEngine.PlaySound(SoundID.Item36, Projectile.Center);
@@ -406,7 +417,13 @@ namespace StarlightRiver.Content.Items.ArmsDealer
 
 		public override void Fire(Vector2 target)
 		{
-			Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center + Vector2.UnitY * -10, target.RotatedByRandom(0.05f) * 8, ProjectileID.Bullet, 7, 1, Projectile.owner);
+			if (Main.myPlayer == Owner.whoAmI)
+			{
+				int projId = Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center + Vector2.UnitY * -10, target.RotatedByRandom(0.05f) * 8, ProjectileID.Bullet, 7, 1, Projectile.owner);
+				Projectile bullet = Main.projectile[projId];
+				bullet.DamageType = DamageClass.Summon; //not synced but hopefully doesn't matter? otherwise we need some other solution
+			}
+
 			SoundEngine.PlaySound(SoundID.Item11, Projectile.Center);
 		}
 	}

--- a/Content/Items/Beach/Accessories.SeaglassLens.cs
+++ b/Content/Items/Beach/Accessories.SeaglassLens.cs
@@ -11,7 +11,7 @@ namespace StarlightRiver.Content.Items.Beach
 
 		public override void Load()
 		{
-			StarlightProjectile.OnHitNPCEvent += BonusDamage;
+			StarlightProjectile.ModifyHitNPCEvent += BonusDamage;
 		}
 
 		public override void SafeSetDefaults()
@@ -20,12 +20,12 @@ namespace StarlightRiver.Content.Items.Beach
 			Item.value = Item.sellPrice(silver: 50);
 		}
 
-		private void BonusDamage(Projectile projectile, NPC target, NPC.HitInfo hit, int damageDone)
+		private void BonusDamage(Projectile projectile, NPC target, ref NPC.HitModifiers modifiers)
 		{
 			Player owner = Main.player[projectile.owner];
 
 			if (owner == Main.LocalPlayer && Equipped(owner) && projectile.DamageType == DamageClass.Summon && Main.rand.NextBool(10))
-				target.SimpleStrikeNPC(damageDone / 2, hit.HitDirection, true);
+				modifiers.SetCrit();
 		}
 
 		public override void AddRecipes()

--- a/Content/Items/Breacher/Accessories.SupplyBeacon.cs
+++ b/Content/Items/Breacher/Accessories.SupplyBeacon.cs
@@ -62,7 +62,7 @@ namespace StarlightRiver.Content.Items.Breacher
 
 		public override void OnHurt(Player.HurtInfo info)
 		{
-			if (cooldown <= 0 && active)
+			if (cooldown <= 0 && active && Main.myPlayer == Player.whoAmI)
 			{
 				damageTicker += info.Damage;
 

--- a/Content/Items/Breacher/Accessories.SupplyBeacon.cs
+++ b/Content/Items/Breacher/Accessories.SupplyBeacon.cs
@@ -315,7 +315,7 @@ namespace StarlightRiver.Content.Items.Breacher
 
 	class SupplyBeaconDefense : SmartBuff
 	{
-		public override string Texture => AssetDirectory.Debug;
+		public override string Texture => AssetDirectory.Buffs + Name;
 
 		public SupplyBeaconDefense() : base("Supply Beacon", "Defense increased", false) { }
 
@@ -334,7 +334,7 @@ namespace StarlightRiver.Content.Items.Breacher
 
 	class SupplyBeaconHeal : SmartBuff
 	{
-		public override string Texture => AssetDirectory.Debug;
+		public override string Texture => AssetDirectory.Buffs + Name;
 
 		public SupplyBeaconHeal() : base("Supply Beacon", "Regeneration increased", false) { }
 
@@ -354,7 +354,7 @@ namespace StarlightRiver.Content.Items.Breacher
 
 	class SupplyBeaconDamage : SmartBuff
 	{
-		public override string Texture => AssetDirectory.Debug;
+		public override string Texture => AssetDirectory.Buffs + Name;
 
 		public SupplyBeaconDamage() : base("Supply Beacon", "Damage increased", false) { }
 

--- a/Content/Items/Breacher/Projectiles.BreachCannonSentry.cs
+++ b/Content/Items/Breacher/Projectiles.BreachCannonSentry.cs
@@ -1,7 +1,9 @@
 ﻿using StarlightRiver.Helpers;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using Terraria.DataStructures;
 using Terraria.Enums;
 using Terraria.Graphics.Effects;
 using Terraria.ID;
@@ -28,6 +30,9 @@ namespace StarlightRiver.Content.Items.Breacher
 
 	public class BreachCannonSentry : ModProjectile, IDrawPrimitive, IDrawAdditive
 	{
+		public static Vector2 tileOriginToAassign;
+		public static float rotationToAssign;
+
 		public Vector2 tileOrigin = Vector2.Zero;
 
 		private List<Vector2> cache;
@@ -90,15 +95,29 @@ namespace StarlightRiver.Content.Items.Breacher
 			Projectile.sentry = true;
 			Projectile.DamageType = DamageClass.Summon;
 			Projectile.ignoreWater = true;
+			Projectile.usesIDStaticNPCImmunity = true;
+			Projectile.idStaticNPCHitCooldown = 10;
+		}
+
+		public override void OnSpawn(IEntitySource source)
+		{
+			tileOrigin = tileOriginToAassign;
+			Projectile.rotation = rotationToAssign;
 		}
 
 		public override void AI()
 		{
 			Projectile.Center = tileWorldPos - originAngleRad.ToRotationVector2() * 26;
-			float rotDifference = Helper.RotationDifference(Projectile.DirectionTo(Main.MouseWorld).ToRotation(), Projectile.rotation);
 
 			if (owner.HeldItem.type == ModContent.ItemType<BreachCannon>())
+			{
+				owner.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+				controlsPlayer.mouseRotationListener = true;
+
+				float rotDifference = Helper.RotationDifference(Projectile.DirectionTo(controlsPlayer.mouseWorld).ToRotation(), Projectile.rotation);
+
 				Projectile.rotation = MathHelper.Lerp(Projectile.rotation, Projectile.rotation + rotDifference, 0.07f);
+			}
 
 			laserStartpoint = Projectile.Center + Projectile.rotation.ToRotationVector2().RotatedBy(InvertRotation() ? 0.2f : -0.2f) * 44;
 			Vector2 offset = CalculateOffset(laserStartpoint, Projectile.rotation, 15, 1);
@@ -125,18 +144,14 @@ namespace StarlightRiver.Content.Items.Breacher
 			SpawnParticles();
 
 			if (!Main.tile[(int)tileOrigin.X, (int)tileOrigin.Y].HasTile && Projectile.timeLeft > 2)
-			{
-				//Main.NewText("Killed at (" + ((int)tileOrigin.X).ToString() + "," + ((int)tileOrigin.Y).ToString() + ")");
 				Projectile.timeLeft = 2;
-			}
 
 			var color = Color.Lerp(Color.Cyan, new Color(0, 0, 255), 0.5f);
 			Lighting.AddLight(laserStartpoint, color.ToVector3() * laserSizeMult);
 		}
 
-		public override void Kill(int timeLeft)
+		public override void OnKill(int timeLeft)
 		{
-			//Main.NewText(Projectile.Center.X.ToString());
 			for (int k = 1; k <= 5; k++)
 				Gore.NewGoreDirect(Projectile.GetSource_Death(), Projectile.position + new Vector2(Main.rand.Next(Projectile.width), Main.rand.Next(Projectile.height)), Main.rand.NextVector2Circular(3, 3), Mod.Find<ModGore>("BreachCannonSentryGore" + k).Type);
 		}
@@ -518,6 +533,18 @@ namespace StarlightRiver.Content.Items.Breacher
 					Dust.NewDustPerfect(superLaserEndpoint + new Vector2(0, 35) + vel * 2, ModContent.DustType<BreachImpactSpark>(), vel, 0, Color.Lerp(color1, color2, Main.rand.NextFloat()), Main.rand.NextFloat(1.25f, 1.6f));
 				}
 			}
+		}
+
+		public override void SendExtraAI(BinaryWriter writer)
+		{
+			writer.WriteVector2(tileOrigin);
+			writer.Write(Projectile.rotation);
+		}
+
+		public override void ReceiveExtraAI(BinaryReader reader)
+		{
+			tileOrigin = reader.ReadVector2();
+			Projectile.rotation = reader.ReadSingle();
 		}
 	}
 }

--- a/Content/Items/Breacher/Weapons.BreachCannon.cs
+++ b/Content/Items/Breacher/Weapons.BreachCannon.cs
@@ -18,6 +18,7 @@ namespace StarlightRiver.Content.Items.Breacher
 		{
 			Item.CloneDefaults(ItemID.QueenSpiderStaff);
 			Item.damage = 12;
+			Item.DamageType = DamageClass.Summon;
 			Item.mana = 12;
 			Item.width = 40;
 			Item.height = 40;
@@ -82,13 +83,10 @@ namespace StarlightRiver.Content.Items.Breacher
 			if (originTile == Vector2.Zero)
 				return false;
 
-			var proj = Projectile.NewProjectileDirect(source, (originTile - Vector2.UnitX.RotatedBy(minDirection * 1.57f)) * 16, velocity, type, damage, knockback, player.whoAmI, minDirection);
-			var mp = proj.ModProjectile as BreachCannonSentry;
+			BreachCannonSentry.rotationToAssign = minDirection * 1.57f + 3.14f;
+			BreachCannonSentry.tileOriginToAassign = originTile;
+			Projectile.NewProjectileDirect(source, (originTile - Vector2.UnitX.RotatedBy(minDirection * 1.57f)) * 16, velocity, type, damage, knockback, player.whoAmI, minDirection);
 
-			//Main.NewText("Spawned at (" + ((int)originTile.X).ToString() + "," + ((int)originTile.Y).ToString() + ")");
-			mp.tileOrigin = originTile;
-			proj.originalDamage = Item.damage;
-			proj.rotation = minDirection * 1.57f + 3.14f;
 			player.UpdateMaxTurrets();
 
 			return false;

--- a/Content/Items/BuriedArtifacts/Artifacts.PirateChestArtifact.cs
+++ b/Content/Items/BuriedArtifacts/Artifacts.PirateChestArtifact.cs
@@ -31,7 +31,7 @@ namespace StarlightRiver.Content.Items.BuriedArtifacts
 		public override void RightClick(Player player)
 		{
 			int bar = (GenVars.gold == TileID.Gold) ? ItemID.PlatinumBar : ItemID.GoldBar;
-			Item.NewItem(Item.GetSource_DropAsItem(), player.Hitbox, bar, Main.rand.Next(5, 11));
+			player.QuickSpawnItem(Item.GetSource_DropAsItem(), bar, Main.rand.Next(5,11));
 
 			int[] gems = new int[]
 			{
@@ -45,10 +45,10 @@ namespace StarlightRiver.Content.Items.BuriedArtifacts
 			int numGems = Main.rand.Next(15, 21);
 
 			for (int i = 0; i < numGems; i++)
-				Item.NewItem(Item.GetSource_DropAsItem(), player.Hitbox, gems[Main.rand.Next(gems.Length)]);
+				player.QuickSpawnItem(Item.GetSource_DropAsItem(), gems[Main.rand.Next(gems.Length)]);
 
-			Item.NewItem(Item.GetSource_DropAsItem(), player.Hitbox, ItemID.GoldCoin, Main.rand.Next(1, 5));
-			Item.NewItem(Item.GetSource_DropAsItem(), player.Hitbox, ItemID.SilverCoin, Main.rand.Next(1, 99));
+			player.QuickSpawnItem(Item.GetSource_DropAsItem(), ItemID.GoldCoin, Main.rand.Next(1, 5));
+			player.QuickSpawnItem(Item.GetSource_DropAsItem(), ItemID.SilverCoin, Main.rand.Next(1, 99));
 		}
 	}
 }

--- a/Content/Items/BuriedArtifacts/Weapons.ArchaeologistsWhip.cs
+++ b/Content/Items/BuriedArtifacts/Weapons.ArchaeologistsWhip.cs
@@ -1,6 +1,7 @@
 ﻿using ReLogic.Content;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata;
 using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.GameContent.Creative;
@@ -131,13 +132,22 @@ namespace StarlightRiver.Content.Items.BuriedArtifacts
 
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			int[] treasure = new int[] {
+
+			// Items can only be spawned on server or singleplayer
+			if (Main.netMode == NetmodeID.MultiplayerClient)
+			{
+				Main.player[Projectile.owner].TryGetModPlayer(out StarlightPlayer sp);
+				sp.SetHitPacketStatus(true);
+				return;
+			}
+
+			int[] treasure = [
 			ModContent.ItemType<AWhip_BlueGem>(),
-			ModContent.ItemType<AWhip_GreenGem>(),
-			ModContent.ItemType<AWhip_RedGem>(),
-			ModContent.ItemType<AWhip_Coin>(),
-			ModContent.ItemType<AWhip_Necklace>(),
-			};
+				ModContent.ItemType<AWhip_GreenGem>(),
+				ModContent.ItemType<AWhip_RedGem>(),
+				ModContent.ItemType<AWhip_Coin>(),
+				ModContent.ItemType<AWhip_Necklace>(),
+			];
 
 			if (Main.rand.NextBool(9))
 			{
@@ -215,7 +225,7 @@ namespace StarlightRiver.Content.Items.BuriedArtifacts
 		public override void SetStaticDefaults()
 		{
 			DisplayName.SetDefault("Treasure buff");
-			Description.SetDefault("Your minions do more damage");
+			Description.SetDefault("Your minions do more contact damage");
 		}
 	}
 

--- a/Content/Items/Desert/Weapons.Sandscript.cs
+++ b/Content/Items/Desert/Weapons.Sandscript.cs
@@ -1,6 +1,9 @@
-﻿using StarlightRiver.Helpers;
+﻿using StarlightRiver.Core;
+using StarlightRiver.Helpers;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using Terraria;
 using Terraria.DataStructures;
 using Terraria.Graphics.Effects;
 using Terraria.ID;
@@ -74,7 +77,6 @@ namespace StarlightRiver.Content.Items.Desert
 		public float Progress => 1f - Projectile.timeLeft / MaxTimeleft;
 
 		public Player Owner => Main.player[Projectile.owner];
-		public Vector2? OwnerMouse => (Main.myPlayer == Owner.whoAmI) ? Main.MouseWorld : null;
 
 		public override string Texture => AssetDirectory.DesertItem + "Sandscript";
 
@@ -103,7 +105,7 @@ namespace StarlightRiver.Content.Items.Desert
 			Projectile.timeLeft = (int)(useSpeed * 0.9f);
 			MaxTimeleft = Projectile.timeLeft;
 
-			Projectile.velocity = Owner.DirectionTo(OwnerMouse.Value);
+			Projectile.velocity = Owner.DirectionTo(Main.MouseWorld);
 			Projectile.rotation = Projectile.velocity.ToRotation();
 		}
 
@@ -121,20 +123,24 @@ namespace StarlightRiver.Content.Items.Desert
 			if (Projectile.timeLeft < MaxTimeleft)
 				Dust.NewDustPerfect(Projectile.Center + Main.rand.NextVector2CircularEdge(lerper, lerper), ModContent.DustType<Dusts.GlowFastDecelerate>(), Main.rand.NextVector2Circular(0.5f, 0.5f), 0, Main.rand.NextBool() ? new Color(30, 230, 200) : new Color(230, 170, 100), 0.4f);
 
+			Owner.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+			controlsPlayer.mouseRotationListener = true;
+
 			if (Projectile.timeLeft == 10)
 			{
-				Projectile.NewProjectile(Projectile.GetSource_FromThis(), Owner.Center, Owner.DirectionTo(OwnerMouse.Value), ModContent.ProjectileType<SandSlash>(), Projectile.damage, Projectile.knockBack, Projectile.owner, SwingDirection);
+				if (Owner.whoAmI == Main.myPlayer)
+					Projectile.NewProjectile(Projectile.GetSource_FromThis(), Owner.Center, Owner.DirectionTo(controlsPlayer.mouseWorld), ModContent.ProjectileType<SandSlash>(), Projectile.damage, Projectile.knockBack, Projectile.owner, SwingDirection);
 
 				for (int i = 0; i < 10; i++)
 				{
-					Dust.NewDustPerfect(Projectile.Center, ModContent.DustType<Dusts.GlowFastDecelerate>(), Owner.DirectionTo(OwnerMouse.Value) * 3f + Main.rand.NextVector2Circular(1.5f, 1.5f), 0, Main.rand.NextBool() ? new Color(30, 230, 200) : new Color(230, 170, 100), 0.4f);
+					Dust.NewDustPerfect(Projectile.Center, ModContent.DustType<Dusts.GlowFastDecelerate>(), Owner.DirectionTo(controlsPlayer.mouseWorld) * 3f + Main.rand.NextVector2Circular(1.5f, 1.5f), 0, Main.rand.NextBool() ? new Color(30, 230, 200) : new Color(230, 170, 100), 0.4f);
 
-					Dust.NewDustPerfect(Projectile.Center, DustType<Dusts.Sand>(), Owner.DirectionTo(OwnerMouse.Value) * 3f + Main.rand.NextVector2Circular(1.5f, 1.5f), 140, default, 0.6f).noGravity = true;
+					Dust.NewDustPerfect(Projectile.Center, DustType<Dusts.Sand>(), Owner.DirectionTo(controlsPlayer.mouseWorld) * 3f + Main.rand.NextVector2Circular(1.5f, 1.5f), 140, default, 0.6f).noGravity = true;
 				}
 			}
 
 			if (Projectile.timeLeft > 10)
-				Projectile.velocity = Vector2.Lerp(Projectile.velocity, Owner.DirectionTo(OwnerMouse.Value), 0.1f);
+				Projectile.velocity = Vector2.Lerp(Projectile.velocity, Owner.DirectionTo(controlsPlayer.mouseWorld), 0.1f);
 		}
 
 		public override bool PreDraw(ref Color lightColor)
@@ -153,6 +159,18 @@ namespace StarlightRiver.Content.Items.Desert
 				Main.spriteBatch.Draw(tex, Projectile.Center + new Vector2(0f, Owner.gfxOffY) - Main.screenPosition, null, lightColor * mult, Projectile.rotation, tex.Size() / 2f, Projectile.scale * MathHelper.Lerp(1f, 2f, EaseBuilder.EaseCubicOut.Ease(1f - Projectile.timeLeft / 10f)), 0f, 0f);
 			return false;
 		}
+
+		public override void SendExtraAI(BinaryWriter writer)
+		{
+			writer.Write(Projectile.timeLeft);
+			writer.Write(Projectile.rotation);
+		}
+
+		public override void ReceiveExtraAI(BinaryReader reader)
+		{
+			Projectile.timeLeft = reader.ReadInt32();
+			Projectile.rotation = reader.ReadSingle();
+		}
 	}
 
 	internal class SandSlash : ModProjectile, IDrawPrimitive
@@ -166,8 +184,6 @@ namespace StarlightRiver.Content.Items.Desert
 		private Trail trail2;
 
 		public ref float SwingDirection => ref Projectile.ai[0];
-
-		public Vector2? OwnerMouse => (Main.myPlayer == Owner.whoAmI) ? Main.MouseWorld : null;
 
 		public Player Owner => Main.player[Projectile.owner];
 
@@ -206,7 +222,8 @@ namespace StarlightRiver.Content.Items.Desert
 					hasPlayedSound = true;
 					Terraria.Audio.SoundEngine.PlaySound(SoundID.Item45, Projectile.Center);
 
-					Core.Systems.CameraSystem.CameraSystem.shake += 5;
+					if (Main.myPlayer == Projectile.owner)
+						Core.Systems.CameraSystem.CameraSystem.shake += 5;
 				}
 			}
 			else
@@ -236,6 +253,9 @@ namespace StarlightRiver.Content.Items.Desert
 
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 		{
+			Owner.TryGetModPlayer(out StarlightPlayer starlightPlayer);
+			starlightPlayer.SetHitPacketStatus(shouldRunProjMethods: true);
+
 			for (int i = 0; i < 4; i++)
 			{
 				Dust.NewDustPerfect(Projectile.Center, ModContent.DustType<Dusts.GlowFastDecelerate>(), target.Center.DirectionTo(Owner.Center) * Main.rand.NextFloat(7f) + Main.rand.NextVector2Circular(2f, 2f), 0, Color.Lerp(new Color(30, 230, 200), new Color(230, 170, 100), 1f - Projectile.timeLeft / maxTimeleft), 0.75f);

--- a/Content/Items/Dungeon/Weapons.Cloudstrike.cs
+++ b/Content/Items/Dungeon/Weapons.Cloudstrike.cs
@@ -156,13 +156,16 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 		private static void CreateStatic(Item item, int charge, Player Player, bool fullCharge = false)
 		{
+			if (Main.myPlayer != Player.whoAmI)
+				return;
+
 			Vector2 dir = Main.rand.NextFloat(6.28f).ToRotationVector2();
 			Vector2 offset = Main.rand.NextBool(4) ? dir * Main.rand.NextFloat(30) : new Vector2(Main.rand.Next(-35, 35), Player.height / 2);
 
-			float smalLCharge = fullCharge ? 0.5f : 0.01f;
+			float smallCharge = fullCharge ? 0.5f : 0.01f;
 
 			var source = new EntitySource_ItemUse(Player, item);
-			var proj = Projectile.NewProjectileDirect(source, Player.Center + offset, dir.RotatedBy(Main.rand.NextFloat(-1, 1)) * 5, ModContent.ProjectileType<CloudstrikeShot>(), 0, 0, Player.whoAmI, smalLCharge, 2);
+			var proj = Projectile.NewProjectileDirect(source, Player.Center + offset, dir.RotatedBy(Main.rand.NextFloat(-1, 1)) * 5, ModContent.ProjectileType<CloudstrikeShot>(), 0, 0, Player.whoAmI, smallCharge, 2);
 			var mp = proj.ModProjectile as CloudstrikeShot;
 			mp.velocityMult = Main.rand.Next(1, 4);
 

--- a/Content/Items/Dungeon/Weapons.Cloudstrike.cs
+++ b/Content/Items/Dungeon/Weapons.Cloudstrike.cs
@@ -3,13 +3,16 @@ using StarlightRiver.Core.Systems.CameraSystem;
 using StarlightRiver.Helpers;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Windows.Forms;
 using Terraria.DataStructures;
 using Terraria.Graphics.Effects;
 using Terraria.ID;
 
 namespace StarlightRiver.Content.Items.Dungeon
 {
+	//POTENTIAL TODO: this weapon's projectile is severely unoptimized and could use a rewrite from the ground up
 	class Cloudstrike : ModItem
 	{
 		public const int MAXCHARGE = 120;
@@ -61,6 +64,18 @@ namespace StarlightRiver.Content.Items.Dungeon
 			(clone as Cloudstrike).counter = (Item.ModItem as Cloudstrike).counter;
 
 			return clone;
+		}
+
+		public override void NetSend(BinaryWriter writer)
+		{
+			writer.Write(charge);
+			writer.Write(counter);
+		}
+
+		public override void NetReceive(BinaryReader reader)
+		{
+			charge = reader.ReadInt32();
+			counter = reader.ReadInt32();
 		}
 
 		public override void ModifyManaCost(Player Player, ref float reduce, ref float mult)
@@ -199,7 +214,7 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 		private Vector2 startPoint = Vector2.Zero;
 
-		private Vector2 mousePos = Vector2.Zero;
+		private Vector2 mousePos = Vector2.Zero; // this doesn't seem like the name matches whatever this is supposed to be
 
 		private float curve; //How much the bolt curves toward it's target position
 
@@ -218,7 +233,7 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 		private int Power => (int)(ChargeSqrt * 3) + 10;
 
-		private Player Player => Main.player[Projectile.owner];
+		private Player Owner => Main.player[Projectile.owner];
 
 		private float Fade => Projectile.extraUpdates == 0 ? EaseFunction.EaseCubicOut.Ease(Projectile.timeLeft / 25f) : 1;
 
@@ -247,25 +262,35 @@ namespace StarlightRiver.Content.Items.Dungeon
 			DisplayName.SetDefault("Electro Shock");
 		}
 
+		public override void OnSpawn(IEntitySource source)
+		{
+			if (!Branch && !Miniature)
+				mousePos = Main.MouseWorld;
+
+			oldRotation = (Main.MouseWorld - Owner.Center).ToRotation();
+		}
+
 		public override void AI()
 		{
 			if (!initialized)
 			{
 				startPoint = Projectile.Center;
-				ManageCaches();
+				
+				if (Main.netMode != NetmodeID.Server)
+					ManageCaches();
+				
 				initialized = true;
+
 				if (!Branch && !Miniature)
 				{
 					Projectile.timeLeft = (int)(Math.Sqrt(ChargeSqrt) * 20) + 45;
-					mousePos = Main.MouseWorld;
 					Projectile.penetrate = 4 + (int)(Charge / 10);
 				}
 
 				if (Charge < 10 && !(Branch || Miniature))
 					followPlayer = true;
 
-				oldRotation = (Main.MouseWorld - Player.Center).ToRotation();
-				oldPlayerPos = Player.Center;
+				oldPlayerPos = Owner.Center;
 			}
 
 			if (Main.netMode != NetmodeID.Server && (Projectile.timeLeft % 4 == 0 || Projectile.timeLeft <= 25))
@@ -276,19 +301,22 @@ namespace StarlightRiver.Content.Items.Dungeon
 			}
 
 			if (Projectile.timeLeft > 36 && !Miniature)
-				Player.itemTime = Player.itemAnimation = (int)(ChargeSqrt + 1) * 3;
+				Owner.itemTime = Owner.itemAnimation = (int)(ChargeSqrt + 1) * 3;
 
-			foreach (Vector2 point in cache)
+			if (Main.netMode != NetmodeID.Server)
 			{
-				Lighting.AddLight(point, baseColor.ToVector3() * (float)Math.Sqrt(ChargeSqrt) * 0.3f * Fade);
-			}
-
-			for (int k = 1; k < cache2.Count; k++)
-			{
-				if (Main.rand.NextBool(40 * (Projectile.extraUpdates + 1)))
+				foreach (Vector2 point in cache)
 				{
-					Vector2 prevPos = k == 1 ? startPoint : cache2[k - 1];
-					Dust.NewDustPerfect(prevPos + new Vector2(0, 30), ModContent.DustType<CloudstrikeGlowLine>(), Vector2.Normalize(cache2[k] - prevPos) * Main.rand.NextFloat(-3, -2), 0, baseColor * (Power / 30f), 0.5f);
+					Lighting.AddLight(point, baseColor.ToVector3() * (float)Math.Sqrt(ChargeSqrt) * 0.3f * Fade);
+				}
+
+				for (int k = 1; k < cache2.Count; k++)
+				{
+					if (Main.rand.NextBool(40 * (Projectile.extraUpdates + 1)))
+					{
+						Vector2 prevPos = k == 1 ? startPoint : cache2[k - 1];
+						Dust.NewDustPerfect(prevPos + new Vector2(0, 30), ModContent.DustType<CloudstrikeGlowLine>(), Vector2.Normalize(cache2[k] - prevPos) * Main.rand.NextFloat(-3, -2), 0, baseColor * (Power / 30f), 0.5f);
+					}
 				}
 			}
 
@@ -305,24 +333,34 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 			CalculateVelocity();
 
-			if (Main.rand.NextBool((int)Charge + 50) && !(Branch || Miniature)) //damaging, large branches
+			if (Main.myPlayer == Projectile.owner)
 			{
-				var proj = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, Projectile.velocity.RotatedBy(Main.rand.NextFloat(-0.7f, 0.7f)), ModContent.ProjectileType<CloudstrikeShot>(), Projectile.damage, Projectile.knockBack, Player.whoAmI, Charge, 1);
-				proj.timeLeft = (int)((Projectile.timeLeft - 25) * 0.75f) + 25;
+				if (Main.rand.NextBool((int)Charge + 50) && !(Branch || Miniature)) //damaging, large branches
+				{
+					var proj = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, Projectile.velocity.RotatedBy(Main.rand.NextFloat(-0.7f, 0.7f)), ModContent.ProjectileType<CloudstrikeShot>(), Projectile.damage, Projectile.knockBack, Owner.whoAmI, Charge, 1);
+					proj.timeLeft = (int)((Projectile.timeLeft - 25) * 0.75f) + 25;
 
-				var modProj = proj.ModProjectile as CloudstrikeShot;
-				modProj.mousePos = proj.Center + proj.velocity * 30;
-				modProj.followPlayer = followPlayer;
-			}
+					var modProj = proj.ModProjectile as CloudstrikeShot;
+					modProj.mousePos = proj.Center + proj.velocity * 30;
+					modProj.followPlayer = followPlayer;
 
-			if (Main.rand.NextBool(10 + (int)Math.Sqrt(Cloudstrike.MAXCHARGE + 2 - Charge)) && !(Branch || Miniature)) //small, non damaging branches
-			{
-				var proj = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, Projectile.velocity.RotatedBy(Main.rand.NextFloat(-0.2f, 0.2f)), ModContent.ProjectileType<CloudstrikeShot>(), 0, 0, Player.whoAmI, 1, 1);
-				proj.timeLeft = Math.Min(Main.rand.Next(40, 70), Projectile.timeLeft);
+					// These post creation force syncs are pretty bad performance/visuals wise
+					// but its a symptom of using the same projectile in wildly different ways instead of a helper for the visuals
+					// And would require a more thorough rewrite to fix
+					NetMessage.SendData(MessageID.SyncProjectile, -1, -1, null, proj.whoAmI);
+				}
 
-				var modProj = proj.ModProjectile as CloudstrikeShot;
-				modProj.mousePos = proj.Center + proj.velocity * 30;
-				modProj.followPlayer = followPlayer;
+				if (Main.rand.NextBool(10 + (int)Math.Sqrt(Cloudstrike.MAXCHARGE + 2 - Charge)) && !(Branch || Miniature)) //small, non damaging branches
+				{
+					var proj = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, Projectile.velocity.RotatedBy(Main.rand.NextFloat(-0.2f, 0.2f)), ModContent.ProjectileType<CloudstrikeShot>(), 0, 0, Owner.whoAmI, 1, 1);
+					proj.timeLeft = Math.Min(Main.rand.Next(40, 70), Projectile.timeLeft);
+
+					var modProj = proj.ModProjectile as CloudstrikeShot;
+					modProj.mousePos = proj.Center + proj.velocity * 30;
+					modProj.followPlayer = followPlayer;
+
+					NetMessage.SendData(MessageID.SyncProjectile, -1, -1, null, proj.whoAmI);
+				}
 			}
 		}
 
@@ -336,6 +374,9 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 		{
+			Owner.TryGetModPlayer(out StarlightPlayer starlightPlayer);
+			starlightPlayer.SetHitPacketStatus(shouldRunProjMethods: true);
+
 			hitTargets.Add(target);
 			Dust.NewDustPerfect(Projectile.Center, ModContent.DustType<CloudstrikeCircleDust>(), Vector2.Zero, 0, default, (float)Math.Pow(ChargeSqrt, 0.3f));
 
@@ -366,6 +407,9 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 		private void ManageCaches(bool addPoint = false)
 		{
+			if (Main.netMode == NetmodeID.Server)
+				return;
+
 			if (cache == null)
 			{
 				cache = new List<Vector2>();
@@ -400,6 +444,9 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 		private void ManageTrails()
 		{
+			if (Main.netMode == NetmodeID.Server)
+				return;
+
 			int sparkMult = Miniature ? 6 : 1;
 			trail ??= new Trail(Main.instance.GraphicsDevice, 50, new TriangularTip(4), factor => thickness * sparkMult * Main.rand.NextFloat(0.75f, 1.25f) * 16 * (float)Math.Pow(ChargeSqrt, 0.7f), factor =>
 			{
@@ -517,14 +564,14 @@ namespace StarlightRiver.Content.Items.Dungeon
 				{
 					dir = mousePos - Projectile.Center;
 
-					Vector2 pToM = mousePos - Player.Center;
-					Vector2 pToL = Projectile.Center - Player.Center;
+					Vector2 pToM = mousePos - Owner.Center;
+					Vector2 pToL = Projectile.Center - Owner.Center;
 					if (pToL.Length() > pToM.Length())
 						reachedMouse = true;
 				}
 				else
 				{
-					dir = mousePos - Player.Center;
+					dir = mousePos - Owner.Center;
 				}
 
 				distance = dir.Length();
@@ -533,7 +580,7 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 			if (Miniature)
 			{
-				Vector2 hostCenter = host == default ? Player.Center : host.Center;
+				Vector2 hostCenter = host == default ? Owner.Center : host.Center;
 				Vector2 dir2 = hostCenter + Main.rand.NextVector2Circular(12, 12) - Projectile.Center;
 				distance = dir2.Length();
 				rotToBe = Vector2.Normalize(dir2).RotatedBy(curve * 3);
@@ -552,7 +599,7 @@ namespace StarlightRiver.Content.Items.Dungeon
 		{
 			if (!followPlayer)
 				return;
-			Vector2 center = Player.Center;
+			Vector2 center = Owner.Center;
 			if (oldPlayerPos != center)
 			{
 				Vector2 offset = center - oldPlayerPos;
@@ -560,16 +607,20 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 				startPoint += offset;
 				Projectile.Center += offset;
-				if (cache != null)
-				{
-					for (int i = 0; i < cache.Count; i++)
-						cache[i] += offset;
-				}
 
-				if (cache2 != null)
+				if (Main.netMode != NetmodeID.Server)
 				{
-					for (int i = 0; i < cache2.Count; i++)
-						cache2[i] += offset;
+					if (cache != null)
+					{
+						for (int i = 0; i < cache.Count; i++)
+							cache[i] += offset;
+					}
+
+					if (cache2 != null)
+					{
+						for (int i = 0; i < cache2.Count; i++)
+							cache2[i] += offset;
+					}
 				}
 			}
 		}
@@ -579,30 +630,53 @@ namespace StarlightRiver.Content.Items.Dungeon
 			if (!followPlayer)
 				return;
 
-			if (Player.itemTime != 1)
+			if (Owner.itemTime != 1)
 				return;
-			float rot = (Main.MouseWorld - Player.Center).ToRotation();
+
+			Owner.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+			controlsPlayer.mouseRotationListener = true;
+
+			float rot = (controlsPlayer.mouseWorld - Owner.Center).ToRotation();
 			if (rot != oldRotation)
 			{
 				float difference = rot - oldRotation;
 
-				startPoint = (startPoint - Player.Center).RotatedBy(difference) + Player.Center;
-				Projectile.Center = (Projectile.Center - Player.Center).RotatedBy(difference) + Player.Center;
+				startPoint = (startPoint - Owner.Center).RotatedBy(difference) + Owner.Center;
+				Projectile.Center = (Projectile.Center - Owner.Center).RotatedBy(difference) + Owner.Center;
 
-				if (cache != null)
+				if (Main.netMode != NetmodeID.Server)
 				{
-					for (int i = 0; i < cache.Count; i++)
-						cache[i] = (cache[i] - Player.Center).RotatedBy(difference) + Player.Center;
-				}
+					if (cache != null)
+					{
+						for (int i = 0; i < cache.Count; i++)
+							cache[i] = (cache[i] - Owner.Center).RotatedBy(difference) + Owner.Center;
+					}
 
-				if (cache2 != null)
-				{
-					for (int i = 0; i < cache2.Count; i++)
-						cache2[i] = (cache2[i] - Player.Center).RotatedBy(difference) + Player.Center;
+					if (cache2 != null)
+					{
+						for (int i = 0; i < cache2.Count; i++)
+							cache2[i] = (cache2[i] - Owner.Center).RotatedBy(difference) + Owner.Center;
+					}
 				}
 
 				oldRotation = rot;
 			}
+		}
+
+		public override void SendExtraAI(BinaryWriter writer)
+		{
+			writer.WritePackedVector2(mousePos);
+			writer.Write(oldRotation);
+			writer.Write(followPlayer);
+			writer.Write(Projectile.timeLeft);
+		}
+
+		public override void ReceiveExtraAI(BinaryReader reader)
+		{
+			mousePos = reader.ReadPackedVector2();
+			oldRotation = reader.ReadSingle();
+			followPlayer = reader.ReadBoolean();
+			Projectile.timeLeft = reader.ReadInt32();
 		}
 	}
 	class CloudstrikeCircleDust : ModDust

--- a/Content/Items/Dungeon/Weapons.SkullBuster.cs
+++ b/Content/Items/Dungeon/Weapons.SkullBuster.cs
@@ -4,6 +4,7 @@ using StarlightRiver.Core.Systems.CameraSystem;
 using StarlightRiver.Helpers;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Terraria.DataStructures;
 using Terraria.Graphics.Effects;
@@ -53,21 +54,16 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 		public override void HoldItem(Player Player)
 		{
-			cooldown--;
-		}
+			Player.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+			controlsPlayer.rightClickListener = true;
 
-		public override bool CanUseItem(Player Player)
-		{
-			if (Player.altFunctionUse == 2)
+			if (controlsPlayer.mouseRight)
 			{
 				Item.useStyle = ItemUseStyleID.Swing;
 				Item.noUseGraphic = true;
 
 				Item.useTime = 15;
 				Item.useAnimation = 15;
-
-				if (cooldown > 0)
-					return false;
 			}
 			else
 			{
@@ -76,6 +72,14 @@ namespace StarlightRiver.Content.Items.Dungeon
 				Item.useStyle = ItemUseStyleID.Shoot;
 				Item.noUseGraphic = false;
 			}
+
+			cooldown--;
+		}
+
+		public override bool CanUseItem(Player Player)
+		{
+			if (Player.altFunctionUse == 2 && cooldown > 0)
+				return false;
 
 			return base.CanUseItem(Player);
 		}
@@ -106,12 +110,11 @@ namespace StarlightRiver.Content.Items.Dungeon
 			{
 				for (int i = 0; i < 4; i++)
 				{
-					var bomb = Projectile.NewProjectileDirect(source, position, velocity.RotatedByRandom(0.4f) * Main.rand.NextFloat(0.8f, 1.3f), type, damage + 15, knockback, player.whoAmI);
-					(bomb.ModProjectile as SkullBomb).crosshairSin = -i * 0.15f;
+					float crosshairSin = -i * 0.15f;
+					var bomb = Projectile.NewProjectileDirect(source, position, velocity.RotatedByRandom(0.4f) * Main.rand.NextFloat(0.8f, 1.3f), type, damage + 15, knockback, player.whoAmI, ai2: crosshairSin);
 				}
 
-				var proj = Projectile.NewProjectileDirect(source, position, Vector2.Zero, ModContent.ProjectileType<SkullBusterProj>(), damage, knockback, player.whoAmI);
-				(proj.ModProjectile as SkullBusterProj).baseItem = Item;
+				Projectile.NewProjectileDirect(source, position, Vector2.Zero, ModContent.ProjectileType<SkullBusterProj>(), damage, knockback, player.whoAmI);
 				cooldown = 130;
 			}
 			else
@@ -132,7 +135,7 @@ namespace StarlightRiver.Content.Items.Dungeon
 				Helper.PlayPitched("Guns/RifleLight", 0.7f, Main.rand.NextFloat(-0.1f, 0.1f), position);
 				Dust.NewDustPerfect(player.Center + offset * 43, ModContent.DustType<Dusts.Smoke>(), Vector2.UnitY * -2 + offset.RotatedByRandom(spread) * 5, 0, new Color(60, 55, 50) * 0.5f, Main.rand.NextFloat(0.5f, 1));
 
-				var proj = Projectile.NewProjectileDirect(player.GetSource_ItemUse(Item), player.Center + offset * 43, velocity * 2, type, damage, knockback, player.whoAmI);
+				Projectile.NewProjectileDirect(player.GetSource_ItemUse(Item), player.Center + offset * 43, velocity * 2, type, damage, knockback, player.whoAmI);
 
 				Projectile.NewProjectile(player.GetSource_ItemUse(Item), position + offset * 43, Vector2.Zero, ModContent.ProjectileType<CoachGunMuzzleFlash>(), 0, 0, player.whoAmI, rot);
 			}
@@ -145,7 +148,7 @@ namespace StarlightRiver.Content.Items.Dungeon
 	{
 		public override string Texture => AssetDirectory.DungeonItem + "SkullBusterReload";
 
-		private Player owner => Main.player[Projectile.owner];
+		private Player Owner => Main.player[Projectile.owner];
 
 		private Vector2 direction = Vector2.One;
 
@@ -169,19 +172,22 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 		public override void AI()
 		{
-			Projectile.Center = owner.Center;
+			Projectile.Center = Owner.Center;
 			Projectile.timeLeft = 2;
 
-			direction = owner.DirectionTo(Main.MouseWorld);
+			Owner.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+			controlsPlayer.mouseRotationListener = true;
 
-			owner.SetCompositeArmFront(true, Player.CompositeArmStretchAmount.Full, direction.ToRotation() - 1.57f);
-			owner.heldProj = Projectile.whoAmI;
-			owner.itemTime = owner.itemAnimation = 3;
+			direction = Owner.DirectionTo(controlsPlayer.mouseWorld);
+
+			Owner.SetCompositeArmFront(true, Player.CompositeArmStretchAmount.Full, direction.ToRotation() - 1.57f);
+			Owner.heldProj = Projectile.whoAmI;
+			Owner.itemTime = Owner.itemAnimation = 3;
 
 			if (direction.X > 0)
-				owner.direction = 1;
+				Owner.direction = 1;
 			else
-				owner.direction = -1;
+				Owner.direction = -1;
 
 			frameCounter++;
 			if (frameCounter % 4 == 0)
@@ -194,8 +200,8 @@ namespace StarlightRiver.Content.Items.Dungeon
 				{
 					for (int i = 0; i < 4; i++)
 					{
-						Vector2 casingOffset = new Vector2(1, -1 * owner.direction).RotatedBy(direction.ToRotation() - 0.6f);
-						Gore.NewGore(Projectile.GetSource_FromThis(), owner.GetFrontHandPosition(Player.CompositeArmStretchAmount.Full, direction.ToRotation() - 1.57f) + casingOffset * 6, new Vector2(owner.direction * -1, -0.5f) * 2, Mod.Find<ModGore>("CoachGunCasing").Type, 1f);
+						Vector2 casingOffset = new Vector2(1, -1 * Owner.direction).RotatedBy(direction.ToRotation() - 0.6f);
+						Gore.NewGore(Projectile.GetSource_FromThis(), Owner.GetFrontHandPosition(Player.CompositeArmStretchAmount.Full, direction.ToRotation() - 1.57f) + casingOffset * 6, new Vector2(Owner.direction * -1, -0.5f) * 2, Mod.Find<ModGore>("CoachGunCasing").Type, 1f);
 					}
 				}
 			}
@@ -223,14 +229,14 @@ namespace StarlightRiver.Content.Items.Dungeon
 			SpriteEffects effects = SpriteEffects.None;
 			float rot = direction.ToRotation();
 
-			if (owner.direction != 1)
+			if (Owner.direction != 1)
 			{
 				effects = SpriteEffects.FlipHorizontally;
 				origin.X = tex.Width - origin.X;
 				rot -= 3.14f;
 			}
 
-			Main.spriteBatch.Draw(tex, owner.GetFrontHandPosition(Player.CompositeArmStretchAmount.Full, direction.ToRotation() - 1.57f) - Main.screenPosition, frame, lightColor, rot, origin, Projectile.scale, effects, 0f);
+			Main.spriteBatch.Draw(tex, Owner.GetFrontHandPosition(Player.CompositeArmStretchAmount.Full, direction.ToRotation() - 1.57f) - Main.screenPosition, frame, lightColor, rot, origin, Projectile.scale, effects, 0f);
 
 			return false;
 		}
@@ -238,8 +244,6 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 	public class SkullBusterProj : ModProjectile
 	{
-		public Item baseItem = default;
-
 		private bool releasingSmoke = false;
 
 		private bool released = false;
@@ -274,7 +278,10 @@ namespace StarlightRiver.Content.Items.Dungeon
 			Projectile.Center = Owner.Center;
 			Owner.heldProj = Projectile.whoAmI;
 
-			if (Main.mouseRight && !released || Owner.itemTime > 3)
+			Owner.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+			controlsPlayer.rightClickListener = true;
+
+			if (controlsPlayer.mouseRight && !released || Owner.itemTime > 3)
 			{
 				Projectile.timeLeft = 30;
 				if (Owner.itemTime < 3)
@@ -325,24 +332,29 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 						if (ammoType != -1)
 						{
-							var proj = Projectile.NewProjectileDirect(null, position + offset * 43, direction, ModContent.ProjectileType<SkullBusterBullet>(), 0, Projectile.knockBack, Owner.whoAmI);
-							(proj.ModProjectile as SkullBusterBullet).target = targetBomb.whoAmI;
 							shotBombs.Add(targetBomb);
 
 							Vector2 gunTip = position + offset * 46;
 
+							if (Owner.whoAmI == Main.myPlayer)
+							{
+								SkullBusterBullet.targetIdentityToAssign = targetBomb.identity;
+								var proj = Projectile.NewProjectileDirect(null, position + offset * 43, direction, ModContent.ProjectileType<SkullBusterBullet>(), 0, Projectile.knockBack, Owner.whoAmI);
+								(proj.ModProjectile as SkullBusterBullet).targetBomb = targetBomb; // Not synced but done this way since the owner doesn't need to iterate over projectiles too
+
+								Projectile.NewProjectile(Projectile.GetSource_FromThis(), gunTip, Vector2.Zero, ModContent.ProjectileType<CoachGunMuzzleFlash>(), 0, 0, Owner.whoAmI, direction.ToRotation());
+							}
+
 							for (int k = 0; k < 15; k++)
 							{
-								Vector2 direction = offset.RotatedByRandom(spread);
+								Vector2 dustDirection = offset.RotatedByRandom(spread);
 
-								Dust.NewDustPerfect(gunTip, ModContent.DustType<Dusts.Glow>(), direction * Main.rand.NextFloat(8), 125, new Color(150, 80, 40), Main.rand.NextFloat(0.2f, 0.5f));
+								Dust.NewDustPerfect(gunTip, ModContent.DustType<Dusts.Glow>(), dustDirection * Main.rand.NextFloat(8), 125, new Color(150, 80, 40), Main.rand.NextFloat(0.2f, 0.5f));
 							}
 
 							Helper.PlayPitched("Guns/PlinkLever", 0.4f, Main.rand.NextFloat(-0.1f, 0.1f), position);
 							Helper.PlayPitched("Guns/RifleLight", 0.7f, Main.rand.NextFloat(-0.1f, 0.1f), position);
 							//Dust.NewDustPerfect(gunTip, ModContent.DustType<Dusts.Smoke>(), Vector2.UnitY * -2 + offset.RotatedByRandom(spread) * 5, 0, new Color(60, 55, 50) * 0.5f, Main.rand.NextFloat(0.5f, 1));
-
-							Projectile.NewProjectile(Projectile.GetSource_FromThis(), gunTip, Vector2.Zero, ModContent.ProjectileType<CoachGunMuzzleFlash>(), 0, 0, Owner.whoAmI, direction.ToRotation());
 						}
 					}
 					else
@@ -373,10 +385,12 @@ namespace StarlightRiver.Content.Items.Dungeon
 			}
 		}
 
-		public override void Kill(int timeLeft)
+		public override void OnKill(int timeLeft)
 		{
 			Helper.PlayPitched("Guns/RevolvingReload", 0.6f, 0, Owner.Center);
-			Projectile.NewProjectile(Projectile.GetSource_FromThis(), Owner.Center, Vector2.Zero, ModContent.ProjectileType<SkullBusterReload>(), 0, 0, Owner.whoAmI);
+			
+			if (Owner.whoAmI == Main.myPlayer)
+				Projectile.NewProjectile(Projectile.GetSource_FromThis(), Owner.Center, Vector2.Zero, ModContent.ProjectileType<SkullBusterReload>(), 0, 0, Owner.whoAmI);
 		}
 
 		public override bool PreDraw(ref Color lightColor)
@@ -434,11 +448,9 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 	public class SkullBomb : ModProjectile
 	{
-		private bool shot = false;
-
 		private float crosshairRotation = 0f;
 
-		public float crosshairSin = 0f;
+		public ref float CrosshairSin => ref Projectile.ai[2];
 
 		public override string Texture => AssetDirectory.DungeonItem + Name;
 
@@ -463,11 +475,11 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 		public override void AI()
 		{
-			if (crosshairSin < 1f)
-				crosshairSin += 0.025f;
+			if (CrosshairSin < 1f)
+				CrosshairSin += 0.025f;
 
-			crosshairSin = MathHelper.Min(crosshairSin, 1);
-			crosshairRotation += 0.05f * crosshairSin;
+			CrosshairSin = MathHelper.Min(CrosshairSin, 1);
+			crosshairRotation += 0.05f * CrosshairSin;
 
 			float progress = 1 - Projectile.timeLeft / 150f;
 
@@ -476,32 +488,29 @@ namespace StarlightRiver.Content.Items.Dungeon
 				var sparks = Dust.NewDustPerfect(Projectile.Center + (Projectile.rotation - 1.57f).ToRotationVector2() * 12, ModContent.DustType<CoachGunSparks>(), (Projectile.rotation + Main.rand.NextFloat(-0.6f, 0.6f)).ToRotationVector2() * Main.rand.NextFloat(0.4f, 1.2f));
 				sparks.fadeIn = progress * 45;
 			}
-
-			var Hitbox = new Rectangle((int)Projectile.Center.X - 50, (int)Projectile.Center.Y - 50, 100, 100);
-			IEnumerable<Projectile> list = Main.projectile.Where(x => x.Hitbox.Intersects(Hitbox));
-
-			foreach (Projectile proj in list)
-			{
-				if (proj.type == ModContent.ProjectileType<SkullBusterBullet>() && (proj.ModProjectile as SkullBusterBullet).target == Projectile.whoAmI && Projectile.timeLeft > 2 && proj.active && proj.velocity.Length() > 1)
-				{
-					shot = true;
-					Projectile.timeLeft = 2;
-					proj.velocity = Vector2.Zero;
-				}
-			}
 		}
 
-		public override void Kill(int timeLeft)
+		public override void OnKill(int timeLeft)
 		{
-			CameraSystem.shake += 3;
-
-			for (int i = 0; i < 3; i++)
+			if (Main.myPlayer == Owner.whoAmI)
 			{
-				var proj = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, Main.rand.NextVector2Circular(7, 7), ProjectileID.Bone, Projectile.damage / 2, Projectile.knockBack, Owner.whoAmI);
-				proj.friendly = true;
-				proj.hostile = false;
-				proj.scale = 0.75f;
+				CameraSystem.shake += 3;
+
+				// Not a syncable projectile right now, just skip this in multiplayer entirely
+				if (Main.netMode == NetmodeID.SinglePlayer) 
+				{ // SYNC TODO: do something about unsyncable vanilla projectile manipulation, like here and in vitric bow
+					for (int i = 0; i < 3; i++)
+					{
+						var proj = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, Main.rand.NextVector2Circular(7, 7), ProjectileID.Bone, Projectile.damage / 2, Projectile.knockBack, Owner.whoAmI);
+						proj.friendly = true; // Not synced. not sure how we would sync manipulating a vanilla projectile post creation like this without some silly global proj shenanigans or maybe something with specialized projectile sources?
+						proj.hostile = false; // Maybe just make this into a custom proj that uses the vanilla texture so it can actually be synced
+						proj.scale = 0.75f;
+					}
+				}
+
+				Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, Vector2.Zero, ModContent.ProjectileType<SkullbusterSkull>(), Projectile.damage, 0, Owner.whoAmI);
 			}
+
 
 			for (int i = 0; i < 10; i++)
 			{
@@ -523,7 +532,6 @@ namespace StarlightRiver.Content.Items.Dungeon
 				Dust.NewDustPerfect(Projectile.Center + Main.rand.NextVector2Circular(25, 25), ModContent.DustType<SkullbusterDustGlow>()).scale = 0.9f;
 			}
 
-			Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, Vector2.Zero, ModContent.ProjectileType<SkullbusterSkull>(), Projectile.damage, 0, Owner.whoAmI);
 			for (int i = 0; i < 10; i++)
 			{
 				Vector2 vel = Main.rand.NextFloat(6.28f).ToRotationVector2();
@@ -563,15 +571,15 @@ namespace StarlightRiver.Content.Items.Dungeon
 			Main.spriteBatch.Draw(tex, Projectile.Center - Main.screenPosition, null, lightColor, Projectile.rotation, tex.Size() / 2, Projectile.scale, SpriteEffects.None, 0f);
 			Main.spriteBatch.Draw(whiteTex, Projectile.Center - Main.screenPosition, null, overlayColor, Projectile.rotation, tex.Size() / 2, Projectile.scale, SpriteEffects.None, 0f);
 
-			if (crosshairSin > 0)
+			if (CrosshairSin > 0)
 			{
 				for (int i = 0; i < 4; i++)
 				{
 					float rot = i / 4f * 6.28f;
 
-					float ease = EaseFunction.EaseQuinticIn.Ease(crosshairSin);
+					float ease = EaseFunction.EaseQuinticIn.Ease(CrosshairSin);
 					Vector2 origin = crosshairTex.Size() * (1.75f + 0.25f * (float)Math.Cos(ease * 3.14f));
-					Main.spriteBatch.Draw(crosshairTex, Projectile.Center - Main.screenPosition, null, Color.Red * crosshairSin, crosshairRotation + rot, origin, 1, SpriteEffects.None, 0f);
+					Main.spriteBatch.Draw(crosshairTex, Projectile.Center - Main.screenPosition, null, Color.Red * CrosshairSin, crosshairRotation + rot, origin, 1, SpriteEffects.None, 0f);
 				}
 			}
 
@@ -600,6 +608,8 @@ namespace StarlightRiver.Content.Items.Dungeon
 			Projectile.tileCollide = false;
 			Projectile.penetrate = -1;
 			Projectile.timeLeft = 50;
+			Projectile.usesLocalNPCImmunity = true; //multiple bombs on one target should combo damage
+			Projectile.localNPCHitCooldown = -1;
 			skullNumber = Main.rand.Next(1, 4);
 			Projectile.rotation = Main.rand.NextFloat(-0.2f, 0.2f);
 		}
@@ -655,10 +665,14 @@ namespace StarlightRiver.Content.Items.Dungeon
 
 	public class SkullBusterBullet : ModProjectile, IDrawPrimitive
 	{
+		public static int targetIdentityToAssign = -1;
+
 		private List<Vector2> cache;
 		private Trail trail;
 
-		public int target = -1;
+		private int targetIdentity = -1;
+
+		public Projectile targetBomb = null;
 
 		public override string Texture => AssetDirectory.BreacherItem + "ExplosiveFlare";
 
@@ -680,12 +694,31 @@ namespace StarlightRiver.Content.Items.Dungeon
 			Main.projFrames[Projectile.type] = 2;
 		}
 
+		public override void OnSpawn(IEntitySource source)
+		{
+			targetIdentity = targetIdentityToAssign;
+			targetIdentityToAssign = -1;
+		}
+
 		public override void AI()
 		{
 			if (Main.netMode != NetmodeID.Server)
 			{
 				ManageCaches();
 				ManageTrail();
+			}
+
+			if (targetBomb != null)
+			{
+				// Scale up bomb hitbox to make hitting it easier
+				var targetHitBox = new Rectangle((int)targetBomb.Center.X - 60, (int)targetBomb.Center.Y - 60, 120, 120);
+				
+				if (Projectile.Hitbox.Intersects(targetHitBox))
+				{
+					Projectile.velocity = Vector2.Zero;
+					Projectile.Kill();
+					targetBomb.timeLeft = 2;
+				}
 			}
 		}
 
@@ -731,6 +764,19 @@ namespace StarlightRiver.Content.Items.Dungeon
 			effect.Parameters["sampleTexture"].SetValue(ModContent.Request<Texture2D>("StarlightRiver/Assets/GlowTrail").Value);
 
 			trail?.Render(effect);
+		}
+
+		public override void SendExtraAI(BinaryWriter writer)
+		{
+			writer.Write(targetIdentity);
+		}
+
+		public override void ReceiveExtraAI(BinaryReader reader)
+		{
+			targetIdentity = reader.ReadInt32();
+
+			if (targetIdentity != -1)
+				targetBomb = Main.projectile.FirstOrDefault(n => n.active && n.identity == targetIdentity);
 		}
 	}
 }

--- a/Content/Items/Gravedigger/Accessories.BloodAmulet.cs
+++ b/Content/Items/Gravedigger/Accessories.BloodAmulet.cs
@@ -133,7 +133,8 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			Owner.TryGetModPlayer(out StarlightPlayer starlightPlayer);
 			starlightPlayer.SetHitPacketStatus(shouldRunProjMethods: true); //only server can spawn items
 
-			target.GetGlobalNPC<BloodAmuletGNPC>().dropHeart = true;
+			if (target.active)
+				target.GetGlobalNPC<BloodAmuletGNPC>().dropHeart = true;
 
 			Projectile.friendly = false;
 

--- a/Content/Items/Gravedigger/Accessories.BloodAmulet.cs
+++ b/Content/Items/Gravedigger/Accessories.BloodAmulet.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Terraria.Graphics.Effects;
 using Terraria.ID;
+using static Humanizer.In;
 
 namespace StarlightRiver.Content.Items.Gravedigger
 {
@@ -48,7 +49,7 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 		private void SpawnBolts(Player player)
 		{
-			while ((GetEquippedInstance(player) as BloodAmulet).storedDamage > 25)
+			while ((GetEquippedInstance(player) as BloodAmulet).storedDamage > 25 && Main.myPlayer == player.whoAmI)
 			{
 				(GetEquippedInstance(player) as BloodAmulet).storedDamage -= 25;
 				Projectile.NewProjectile(player.GetSource_Accessory(Item), player.Center, Main.rand.NextVector2Circular(10, 10), ModContent.ProjectileType<BloodAmuletBolt>(), 25, 0, player.whoAmI);
@@ -77,15 +78,9 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 		public bool dropHeart = false;
 
-		public override void OnHitByItem(NPC npc, Player player, Item item, NPC.HitInfo hit, int damageDone)
+		public override void OnKill(NPC npc)
 		{
-			if (dropHeart && npc.life <= 0)
-				Item.NewItem(npc.GetSource_Loot(), npc.Center, ItemID.Heart);
-		}
-
-		public override void OnHitByProjectile(NPC npc, Projectile projectile, NPC.HitInfo hit, int damageDone)
-		{
-			if (dropHeart && npc.life <= 0)
+			if (dropHeart)
 				Item.NewItem(npc.GetSource_Loot(), npc.Center, ItemID.Heart);
 		}
 	}
@@ -96,6 +91,8 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 		private List<Vector2> cache;
 		private Trail trail;
+
+		public Player Owner => Main.player[Projectile.owner];
 
 		public override string Texture => AssetDirectory.Assets + "Invisible";
 
@@ -112,6 +109,8 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			Projectile.height = 20;
 			Projectile.friendly = true;
 			Projectile.penetrate = -1;
+			Projectile.usesLocalNPCImmunity = true;
+			Projectile.localNPCHitCooldown = -1;
 			Projectile.timeLeft = 450;
 			Projectile.tileCollide = false;
 			Projectile.ignoreWater = true;
@@ -121,12 +120,19 @@ namespace StarlightRiver.Content.Items.Gravedigger
 		public override void AI()
 		{
 			Movement();
-			ManageCaches();
-			ManageTrail();
+
+			if (Main.netMode != NetmodeID.Server)
+			{
+				ManageCaches();
+				ManageTrail();
+			}
 		}
 
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 		{
+			Owner.TryGetModPlayer(out StarlightPlayer starlightPlayer);
+			starlightPlayer.SetHitPacketStatus(shouldRunProjMethods: true); //only server can spawn items
+
 			target.GetGlobalNPC<BloodAmuletGNPC>().dropHeart = true;
 
 			Projectile.friendly = false;

--- a/Content/Items/Gravedigger/Weapons.BloodBolter.cs
+++ b/Content/Items/Gravedigger/Weapons.BloodBolter.cs
@@ -1,14 +1,19 @@
+using Microsoft.CodeAnalysis;
 using StarlightRiver.Content.Dusts;
 using StarlightRiver.Core.Systems.CameraSystem;
 using StarlightRiver.Helpers;
 using System;
+using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
+using static Humanizer.In;
 
 namespace StarlightRiver.Content.Items.Gravedigger
 {
 	public class BloodBolter : ModItem
 	{
+		// SYNC TODO: a projectile hitting a mob and "killing" them but not having it actually kill is really jank in mp. this probably needs another pass
+		
 		public override string Texture => AssetDirectory.GravediggerItem + Name;
 
 		public override void SetStaticDefaults()
@@ -139,6 +144,8 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 	internal class BloodBolt : ModProjectile
 	{
+		private Player Owner => Main.player[Projectile.owner];
+
 		public override string Texture => AssetDirectory.GravediggerItem + Name;
 
 		public override void SetStaticDefaults()
@@ -175,18 +182,26 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			return false;
 		}
 
-		public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers) //ModifyHitNPC so it runs before enemies prehurt method
+		public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers)
 		{
-			BloodBolterGNPC GNPC = target.GetGlobalNPC<BloodBolterGNPC>();
-			GNPC.hitFromBolter = true;
-			GNPC.boltOffset = target.Center - Projectile.Center;
-			GNPC.bolt = Projectile;
+			if (target.active && !target.boss && target.knockBackResist != 0 && Helper.IsFleshy(target))
+			{
+				modifiers.SetMaxDamage(target.life - 1); // Cap damage to not kill NPC outright, we'll assume 1 off lethal is a blood bolter "kill"
+				Owner.TryGetModPlayer(out StarlightPlayer starlightPlayer);
+				starlightPlayer.SetHitPacketStatus(shouldRunProjMethods: true);
 
-			GoreDestroyerNPC goreDestroyerNPC = target.GetGlobalNPC<GoreDestroyerNPC>();
-			goreDestroyerNPC.destroyGore = true;
+				GoreDestroyerNPC goreDestroyerNPC = target.GetGlobalNPC<GoreDestroyerNPC>();
+				goreDestroyerNPC.destroyGore = true;
+			}
 		}
 
-		public override void Kill(int timeLeft)
+		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
+		{
+			if (target.life <= 1 && target.active && !target.boss && target.knockBackResist != 0 && Helper.IsFleshy(target))
+				BloodBolterGNPC.MarkForDeath(target, Projectile);
+		}
+
+		public override void OnKill(int timeLeft)
 		{
 			Terraria.Audio.SoundEngine.PlaySound(SoundID.Item10, Projectile.Center);
 
@@ -208,12 +223,19 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 		private float Radius => 150 * (float)Math.Sqrt(Progress) * radiusMult;
 
+
+		private bool hasDoneVisuals = false;
+
+		public ref float GoreX => ref Projectile.ai[0];
+		public ref float GoreY => ref Projectile.ai[1];
+
 		public override void SetDefaults()
 		{
 			Projectile.width = 80;
 			Projectile.height = 80;
 			Projectile.DamageType = DamageClass.Ranged;
 			Projectile.friendly = true;
+			Projectile.hostile = false;
 			Projectile.tileCollide = false;
 			Projectile.penetrate = -1;
 			Projectile.timeLeft = 10;
@@ -224,9 +246,30 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			DisplayName.SetDefault("Blood Bolter");
 		}
 
-		public override bool PreDraw(ref Color lightColor)
+		public override void AI()
 		{
-			return false;
+			if (!hasDoneVisuals && Main.netMode != NetmodeID.Server)
+			{
+				hasDoneVisuals = true;
+
+				Helper.PlayPitched("Impacts/GoreHeavy", 0.5f, Main.rand.NextFloat(-0.1f, 0.1f), Projectile.Center);
+				CameraSystem.shake += 8;
+				Vector2 goreVelocity = new Vector2(GoreX, GoreY);
+				Vector2 direction = -Vector2.Normalize(goreVelocity);
+
+				for (int i = 0; i < 16; i++)
+				{
+					Dust.NewDustPerfect(Projectile.Center - goreVelocity + Main.rand.NextVector2Circular(Projectile.width / 2, Projectile.height / 2), DustID.Blood, Main.rand.NextVector2Circular(5, 5), 0, default, 1.4f);
+					Dust.NewDustPerfect(Projectile.Center - goreVelocity + Main.rand.NextVector2Circular(Projectile.width / 2, Projectile.height / 2), DustID.Blood, direction.RotatedBy(Main.rand.NextFloat(-0.9f, 0.9f)) * Main.rand.NextFloat(3, 8), 0, default, 2.1f);
+					Dust.NewDustPerfect(Projectile.Center - goreVelocity + Main.rand.NextVector2Circular(Projectile.width / 2, Projectile.height / 2), ModContent.DustType<BloodMetaballDust>(), direction.RotatedBy(Main.rand.NextFloat(-0.9f, 0.9f)) * Main.rand.NextFloat(3, 8), 0, default, 0.3f);
+					Dust.NewDustPerfect(Projectile.Center - goreVelocity + Main.rand.NextVector2Circular(Projectile.width / 2, Projectile.height / 2), ModContent.DustType<BloodMetaballDustLight>(), direction.RotatedBy(Main.rand.NextFloat(-0.9f, 0.9f)) * Main.rand.NextFloat(3, 8), 0, default, 0.3f);
+				}
+
+				for (int i = 0; i < 8; i++)
+				{
+					Dust.NewDustPerfect(Projectile.Center - goreVelocity + Main.rand.NextVector2Circular(Projectile.width / 2, Projectile.height / 2), ModContent.DustType<SmokeDustColor>(), Main.rand.NextVector2Circular(3, 3), 0, Color.DarkRed, Main.rand.NextFloat(1, 1.5f));
+				}
+			}
 		}
 
 		public override bool? Colliding(Rectangle projHitbox, Rectangle targetHitbox)
@@ -240,13 +283,16 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 			return false;
 		}
+
+		public override bool PreDraw(ref Color lightColor)
+		{
+			return false;
+		}
 	}
 
 	public class BloodBolterGNPC : GlobalNPC
 	{
-		public bool hitFromBolter = false;
-
-		public Projectile bolt = default;
+		public Projectile storedBolt = default;
 		public Vector2 boltOffset = Vector2.Zero;
 
 		public bool markedForDeath = false;
@@ -255,83 +301,65 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 		public override bool InstancePerEntity => true;
 
-		public override void ResetEffects(NPC npc)
-		{
-			hitFromBolter = false;
-		}
-
 		public override void PostAI(NPC npc)
 		{
-			if (markedForDeath && bolt != default)
+			if (markedForDeath && storedBolt != default)
 			{
-				npc.Center = bolt.Center + boltOffset + new Vector2(3, 3);
-				npc.velocity = bolt.velocity;
+				npc.Center = storedBolt.Center + boltOffset + new Vector2(3, 3);
+				npc.velocity = storedBolt.velocity;
 
 				deathCounter++;
 
-				if (!bolt.active || (npc.collideX || npc.collideY) && deathCounter > 2)
+				if (!storedBolt.active || (npc.collideX || npc.collideY) && deathCounter > 2)
 				{
-					bolt.active = false;
+					SpawnBlood(npc, storedBolt);
+					markedForDeath = false;
+					storedBolt.active = false;
 					npc.Kill();
-					SpawnBlood(npc, bolt);
 				}
 			}
 		}
 
-		public override bool PreKill(NPC npc)
+		public override bool CheckActive(NPC npc)
 		{
-			if (hitFromBolter && !npc.boss && npc.knockBackResist != 0 && Helper.IsFleshy(npc))
+			if (markedForDeath && storedBolt != default )
 				return false;
 
-			return base.PreKill(npc);
+			return true;
 		}
 
-		public override bool CheckDead(NPC npc)
+		public static void MarkForDeath(NPC target, Projectile bolt)
 		{
-			if (hitFromBolter && !markedForDeath && !npc.boss && npc.knockBackResist != 0 && Helper.IsFleshy(npc))
-			{
-				Helper.PlayPitched("Impale", 0.5f, Main.rand.NextFloat(-0.1f, 0.1f), npc.Center);
-				npc.life = 1;
-				markedForDeath = true;
-				npc.immortal = true;
-				npc.noTileCollide = false;
-				npc.noGravity = true;
+			Helper.PlayPitched("Impale", 0.5f, Main.rand.NextFloat(-0.1f, 0.1f), target.Center);
+			target.life = 1;
+			target.immortal = true;
+			target.noTileCollide = false;
+			target.noGravity = true;
+			target.active = true; // Force active for mp? this could be a bad idea for high latency environments, needs more testing
 
-				npc.width -= 6;
-				npc.height -= 6;
+			target.width -= 6;
+			target.height -= 6;
 
-				if (bolt != default)
-				{
-					bolt.friendly = false;
-					bolt.penetrate++;
-				}
+			bolt.friendly = false;
+			bolt.penetrate++;
 
-				return false;
-			}
+			if (bolt.timeLeft < 20)
+				bolt.timeLeft = 20;
+			else if (bolt.timeLeft > 30)
+				bolt.timeLeft = 30;
 
-			return base.CheckDead(npc);
+			BloodBolterGNPC GNPC = target.GetGlobalNPC<BloodBolterGNPC>();
+			GNPC.markedForDeath = true;
+
+			GNPC.boltOffset = target.Center - bolt.Center;
+			GNPC.storedBolt = bolt;
 		}
 
 		private static void SpawnBlood(NPC npc, Projectile projectile)
 		{
-			Helper.PlayPitched("Impacts/GoreHeavy", 0.5f, Main.rand.NextFloat(-0.1f, 0.1f), npc.Center);
-			CameraSystem.shake += 8;
-			Vector2 direction = -Vector2.Normalize(projectile.velocity);
-
-			for (int i = 0; i < 16; i++)
-			{
-				Dust.NewDustPerfect(npc.Center - projectile.velocity + Main.rand.NextVector2Circular(npc.width / 2, npc.height / 2), DustID.Blood, Main.rand.NextVector2Circular(5, 5), 0, default, 1.4f);
-				Dust.NewDustPerfect(npc.Center - projectile.velocity + Main.rand.NextVector2Circular(npc.width / 2, npc.height / 2), DustID.Blood, direction.RotatedBy(Main.rand.NextFloat(-0.9f, 0.9f)) * Main.rand.NextFloat(3, 8), 0, default, 2.1f);
-				Dust.NewDustPerfect(npc.Center - projectile.velocity + Main.rand.NextVector2Circular(npc.width / 2, npc.height / 2), ModContent.DustType<BloodMetaballDust>(), direction.RotatedBy(Main.rand.NextFloat(-0.9f, 0.9f)) * Main.rand.NextFloat(3, 8), 0, default, 0.3f);
-				Dust.NewDustPerfect(npc.Center - projectile.velocity + Main.rand.NextVector2Circular(npc.width / 2, npc.height / 2), ModContent.DustType<BloodMetaballDustLight>(), direction.RotatedBy(Main.rand.NextFloat(-0.9f, 0.9f)) * Main.rand.NextFloat(3, 8), 0, default, 0.3f);
-			}
-
-			for (int i = 0; i < 8; i++)
-			{
-				Dust.NewDustPerfect(npc.Center - projectile.velocity + Main.rand.NextVector2Circular(npc.width / 2, npc.height / 2), ModContent.DustType<SmokeDustColor>(), Main.rand.NextVector2Circular(3, 3), 0, Color.DarkRed, Main.rand.NextFloat(1, 1.5f));
-			}
-
-			Projectile.NewProjectile(new EntitySource_HitEffect(npc), npc.Center, Vector2.Zero, ModContent.ProjectileType<BloodBolterExplosion>(), (int)(projectile.damage * 1.6f), projectile.knockBack, projectile.owner);
+			// For the sake of mp compat this projectile is going to be spawned by the server. Player will miss out on some DPS calcs / onhit procs but its better than totally non-functional
+			if (Main.netMode != NetmodeID.MultiplayerClient)
+				Projectile.NewProjectile(new EntitySource_Parent(projectile), npc.Center, Vector2.Zero, ModContent.ProjectileType<BloodBolterExplosion>(), (int)(projectile.damage * 1.6f), projectile.knockBack, Owner: Main.myPlayer, ai0: projectile.velocity.X, ai1: projectile.velocity.Y);
 		}
 	}
 }

--- a/Content/Items/Gravedigger/Weapons.GravediggerItem.cs
+++ b/Content/Items/Gravedigger/Weapons.GravediggerItem.cs
@@ -231,7 +231,7 @@ namespace StarlightRiver.Content.Items.Gravedigger
 				Projectile.frameCounter = 0;
 			}
 
-			if (CheckFrameDeath()) //TODO: Sync in multiPlayer
+			if (CheckFrameDeath())
 			{
 				SlashWindow--;
 				if (Owner == Main.LocalPlayer)

--- a/Content/Items/Gravedigger/Weapons.GravediggerItem.cs
+++ b/Content/Items/Gravedigger/Weapons.GravediggerItem.cs
@@ -118,7 +118,6 @@ namespace StarlightRiver.Content.Items.Gravedigger
 		/// </summary>
 		private void Reinitialize()
 		{
-			Main.NewText("reinit: " + Main.time);
 			directionTwo = Main.MouseWorld - Owner.MountedCenter;
 			directionTwo.Normalize();
 			Owner.ChangeDir(Main.MouseWorld.X > Owner.MountedCenter.X ? 1 : -1);

--- a/Content/Items/Gravedigger/Weapons.GravediggerItem.cs
+++ b/Content/Items/Gravedigger/Weapons.GravediggerItem.cs
@@ -2,6 +2,7 @@ using StarlightRiver.Content.Buffs;
 using StarlightRiver.Core.Systems.CameraSystem;
 using StarlightRiver.Helpers;
 using System;
+using System.IO;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
@@ -65,6 +66,8 @@ namespace StarlightRiver.Content.Items.Gravedigger
 		private const int COLUMNTHREEFRAMES = 3;
 		private const int COLUMNFOURFRAMES = 4;
 
+		private bool shouldDoSFX = true;
+
 		private int frameX = 0;
 		private int SlashWindow = 0;
 		private Vector2 direction = Vector2.Zero;
@@ -88,13 +91,7 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			Projectile.ownerHitCheck = true;
 		}
 
-		Player Player => Main.player[Projectile.owner];
-
-		private bool FirstTickOfSwing
-		{
-			get => Projectile.ai[1] == 0;
-			set => Projectile.ai[1] = value ? 0 : 1;
-		}
+		Player Owner => Main.player[Projectile.owner];
 
 		private int SwingFrame
 		{
@@ -110,97 +107,119 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			3 => new Vector2(FRAMEWIDTH * 0.35f, FRAMEHEIGHT * 0.6f),
 			_ => Vector2.Zero,
 		};
-		public override void AI()
+
+		public override void OnSpawn(IEntitySource source)
 		{
-			Projectile.velocity = Vector2.Zero;
-			if (FirstTickOfSwing)
+			Reinitialize();
+		}
+
+		/// <summary>
+		/// resets the projectile to an initial state using the players mouse / controls to determine, and sets a netupdate to be sent
+		/// </summary>
+		private void Reinitialize()
+		{
+			Main.NewText("reinit: " + Main.time);
+			directionTwo = Main.MouseWorld - Owner.MountedCenter;
+			directionTwo.Normalize();
+			Owner.ChangeDir(Main.MouseWorld.X > Owner.MountedCenter.X ? 1 : -1);
+			Projectile.frame = 0;
+			Projectile.frameCounter = 0;
+			SlashWindow = 30;
+
+			if (Owner.controlUp)
 			{
-				directionTwo = Main.MouseWorld - Player.MountedCenter;
-				directionTwo.Normalize();
-				Player.ChangeDir(Main.MouseWorld.X > Player.MountedCenter.X ? 1 : -1);
-				Projectile.frame = 0;
-				Projectile.frameCounter = 0;
-				SlashWindow = 30;
-				FirstTickOfSwing = false;
-				if (Player.controlUp)
+				direction = new Vector2(Owner.direction, -1);
+				SwingFrame = 2;
+			}
+			else if (Owner.controlDown)
+			{
+				Owner.GetModPlayer<GravediggerPlayer>().Combo = 0;
+				direction = new Vector2(Owner.direction, -1);
+				SwingFrame = 3;
+			}
+			else
+			{
+				Owner.GetModPlayer<GravediggerPlayer>().Combo++;
+				SwingFrame = Owner.GetModPlayer<GravediggerPlayer>().SwingFrame == 1 ? 0 : 1;
+				if (SwingFrame == 0)
 				{
-					direction = new Vector2(Player.direction, -1);
-					SwingFrame = 2;
-				}
-				else if (Player.controlDown)
-				{
-					Player.GetModPlayer<GravediggerPlayer>().Combo = 0;
-					direction = new Vector2(Player.direction, -1);
-					SwingFrame = 3;
+					direction = new Vector2(Owner.direction, 1);
 				}
 				else
 				{
-					Player.GetModPlayer<GravediggerPlayer>().Combo++;
-					SwingFrame = Player.GetModPlayer<GravediggerPlayer>().SwingFrame == 1 ? 0 : 1;
-					if (SwingFrame == 0)
-					{
-						direction = new Vector2(Player.direction, 1);
-					}
-					else
-					{
-						direction = new Vector2(Player.direction, -1);
-					}
+					direction = new Vector2(Owner.direction, -1);
 				}
-
-				direction.Normalize();
-				Player.GetModPlayer<GravediggerPlayer>().SwingFrame = SwingFrame;
-
-				DoSFX();
 			}
 
-			Player.heldProj = Projectile.whoAmI;
-			Player.itemTime = 2;
-			Player.itemAnimation = 2;
-			Player.GetModPlayer<GravediggerPlayer>().SwingDelay = 2;
+			direction.Normalize();
+			Owner.GetModPlayer<GravediggerPlayer>().SwingFrame = SwingFrame;
+
+			shouldDoSFX = true;
+
+			Projectile.netUpdate = true;
+		}
+
+		public override void AI()
+		{
+			Projectile.velocity = Vector2.Zero;
+			if (shouldDoSFX)
+			{
+				shouldDoSFX = false;
+
+				Helper.PlayPitched("Effects/HeavyWhooshShort", 0.4f, Main.rand.NextFloat(-0.1f, 0.1f), Projectile.Center);
+			}
+
+			Owner.heldProj = Projectile.whoAmI;
+			Owner.itemTime = 2;
+			Owner.itemAnimation = 2;
+			Owner.GetModPlayer<GravediggerPlayer>().SwingDelay = 2;
 			Vector2 frameOrigin;
-			if (Player.direction < 0)
+			if (Owner.direction < 0)
 				frameOrigin = new Vector2(FRAMEWIDTH, FRAMEHEIGHT) - SwingOrigin;
 			else
 				frameOrigin = SwingOrigin;
 
-			Projectile.position = Player.MountedCenter - frameOrigin;
+			Projectile.position = Owner.MountedCenter - frameOrigin;
 			if (SwingFrame < 2)
 			{
 				if (!CheckFrameDeath())
 				{
 					if (SwingFrame == 0 && Projectile.frame < 3)
-						direction = direction.RotatedBy(Player.direction * 0.3f);
+						direction = direction.RotatedBy(Owner.direction * 0.3f);
 					else if (SwingFrame == 1)
-						direction = direction.RotatedBy(Player.direction * -0.45f);
+						direction = direction.RotatedBy(Owner.direction * -0.45f);
 				}
 
-				Player.ChangeDir(Main.MouseWorld.X > Player.MountedCenter.X ? 1 : -1);
+				Owner.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+				controlsPlayer.mouseRotationListener = true;
+
+				Owner.ChangeDir(controlsPlayer.mouseWorld.X > Owner.MountedCenter.X ? 1 : -1);
 				Projectile.position += directionTwo * 10;
-				Player.itemRotation = MathHelper.WrapAngle(direction.ToRotation() - ((Player.direction < 0) ? 0 : MathHelper.Pi));
-				Projectile.rotation = MathHelper.WrapAngle(Player.AngleFrom(Projectile.position + frameOrigin) - ((Player.direction < 0) ? 0 : MathHelper.Pi));
+				Owner.itemRotation = MathHelper.WrapAngle(direction.ToRotation() - ((Owner.direction < 0) ? 0 : MathHelper.Pi));
+				Projectile.rotation = MathHelper.WrapAngle(Owner.AngleFrom(Projectile.position + frameOrigin) - ((Owner.direction < 0) ? 0 : MathHelper.Pi));
 			}
 			else
 			{
 				if (!CheckFrameDeath())
 				{
 					if (SwingFrame == 2) //swing UP
-						direction = direction.RotatedBy(Player.direction * -0.3f);
+						direction = direction.RotatedBy(Owner.direction * -0.3f);
 					else if (SwingFrame == 3) //swing DOWN
-						direction = direction.RotatedBy(Player.direction * -0.2f);
+						direction = direction.RotatedBy(Owner.direction * -0.2f);
 				}
 
-				Player.itemRotation = MathHelper.WrapAngle(direction.ToRotation() - ((Player.direction < 0) ? 0 : MathHelper.Pi));
+				Owner.itemRotation = MathHelper.WrapAngle(direction.ToRotation() - ((Owner.direction < 0) ? 0 : MathHelper.Pi));
 				Projectile.rotation = 0;
 			}
 
 			#region hardcoding
-			if (SwingFrame == 3 && Player.direction < 0)
+			if (SwingFrame == 3 && Owner.direction < 0)
 				Projectile.position -= new Vector2(5, 20);
 
 			if (SwingFrame == 2)
-				Projectile.position.X += 14 * Player.direction;
+				Projectile.position.X += 14 * Owner.direction;
 
-			if (SwingFrame == 1 && Player.direction < 0)
+			if (SwingFrame == 1 && Owner.direction < 0)
 				Projectile.position.Y += 12;
 			#endregion
 
@@ -216,15 +235,15 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			if (CheckFrameDeath()) //TODO: Sync in multiPlayer
 			{
 				SlashWindow--;
-				if (Player == Main.LocalPlayer)
+				if (Owner == Main.LocalPlayer)
 				{
 					if (Main.mouseLeft && SlashWindow < 20)
 					{
-						FirstTickOfSwing = true;
+						Reinitialize();
 					}
 					else if (SlashWindow < 0)
 					{
-						Player.GetModPlayer<GravediggerPlayer>().Combo = 0;
+						Owner.GetModPlayer<GravediggerPlayer>().Combo = 0;
 						Projectile.active = false;
 					}
 				}
@@ -253,10 +272,6 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			return Projectile.frame >= deathFrame;
 		}
 
-		private void DoSFX()
-		{
-			Helper.PlayPitched("Effects/HeavyWhooshShort", 0.4f, Main.rand.NextFloat(-0.1f, 0.1f), Projectile.Center);
-		}
 		public override Color? GetAlpha(Color lightColor)
 		{
 			return Color.Lerp(lightColor, Color.White, 0.2f);
@@ -269,10 +284,10 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			SpriteEffects effects;
 
 			Vector2 frameOrigin = SwingOrigin;
-			if (Player.direction < 0)
+			if (Owner.direction < 0)
 				frameOrigin.X = FRAMEWIDTH - SwingOrigin.X;
 
-			if (Player.direction < 0)
+			if (Owner.direction < 0)
 				effects = SpriteEffects.None;
 			else
 				effects = SpriteEffects.FlipHorizontally;
@@ -289,9 +304,14 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			Player Player = Main.player[Projectile.owner];
-			CameraSystem.shake += 3;
+			Main.player[Projectile.owner].TryGetModPlayer(out StarlightPlayer sp);
+			sp.SetHitPacketStatus(true);
+
+			if (Main.myPlayer == Owner.whoAmI)
+				CameraSystem.shake += 3;
+
 			Helper.PlayPitched("Impacts/GoreLight", 0.4f, Main.rand.NextFloat(-0.1f, 0.1f), target.Center);
+
 			if (target.knockBackResist != 0)
 			{
 				switch (SwingFrame)
@@ -307,7 +327,7 @@ namespace StarlightRiver.Content.Items.Gravedigger
 					case 2:
 						if (!target.noGravity)
 						{
-							target.AddBuff(ModContent.BuffType<ShovelSlowFall>(), 120);
+							target.AddBuff(ModContent.BuffType<ShovelSlowFall>(), 120, true);
 							target.velocity.Y = -8f;
 						}
 
@@ -315,8 +335,8 @@ namespace StarlightRiver.Content.Items.Gravedigger
 					case 3:
 						if (!target.collideY && !target.noGravity)
 						{
-							target.AddBuff(ModContent.BuffType<ShovelQuickFall>(), 60);
-							target.GetGlobalNPC<GravediggerNPC>().SlamPlayer = Player;
+							target.AddBuff(ModContent.BuffType<ShovelQuickFall>(), 60, true);
+							target.GetGlobalNPC<GravediggerNPC>().SlamPlayer = Owner;
 						}
 
 						break;
@@ -330,7 +350,7 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 			if (SwingFrame < 2)
 			{
-				modifiers.HitDirectionOverride = Math.Sign(target.Center.X - Player.Center.X);
+				modifiers.HitDirectionOverride = Math.Sign(target.Center.X - Owner.Center.X);
 				if (target.HasBuff(ModContent.BuffType<ShovelSlowFall>()))
 					modifiers.Knockback *= 0.3f;
 			}
@@ -380,6 +400,30 @@ namespace StarlightRiver.Content.Items.Gravedigger
 				dustDirection2 *= Main.rand.NextFloat(0.5f, 4f + knockback);
 				Dust.NewDustPerfect(target.Center, ModContent.DustType<Dusts.BloodMetaballDustLight>(), dustDirection2, 0, default, 0.2f);
 			}
+		}
+
+		public override void SendExtraAI(BinaryWriter writer)
+		{
+			writer.WritePackedVector2(directionTwo);
+			writer.WritePackedVector2(direction);
+			writer.Write(Projectile.frame);
+			writer.Write(Projectile.frameCounter);
+			writer.Write(SlashWindow);
+			writer.Write(SwingFrame);
+			writer.Write(shouldDoSFX);
+		}
+
+		public override void ReceiveExtraAI(BinaryReader reader)
+		{
+			directionTwo = reader.ReadPackedVector2();
+			direction = reader.ReadPackedVector2();
+			Projectile.frame = reader.ReadInt32();
+			Projectile.frameCounter = reader.ReadInt32();
+			SlashWindow = reader.ReadInt32();
+			SwingFrame = reader.ReadInt32();
+			Owner.GetModPlayer<GravediggerPlayer>().SwingFrame = SwingFrame;
+			shouldDoSFX = reader.ReadBoolean();
+
 		}
 	}
 

--- a/Content/Items/Gravedigger/Weapons.RadculasRapier.cs
+++ b/Content/Items/Gravedigger/Weapons.RadculasRapier.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Terraria.DataStructures;
 using Terraria.ID;
+using static Humanizer.In;
 
 namespace StarlightRiver.Content.Items.Gravedigger
 {
@@ -55,6 +56,12 @@ namespace StarlightRiver.Content.Items.Gravedigger
 				Projectile.NewProjectile(source, position, velocity, type, damage, knockback, player.whoAmI);
 
 			return false;
+		}
+
+		public override void HoldItem(Player player)
+		{
+			player.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+			controlsPlayer.mouseListener = true; // Add listener here to have BEFORE projectile is spawned
 		}
 
 		public override bool CanUseItem(Player player)
@@ -254,6 +261,8 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 		public Player.CompositeArmStretchAmount stretch = Player.CompositeArmStretchAmount.Full;
 
+		private bool isInitialized = false;
+
 		public override string Texture => AssetDirectory.MiscItem + "RadculasRapier_Spear";
 
 		public Player Owner => Main.player[Projectile.owner];
@@ -282,14 +291,15 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			Projectile.localNPCHitCooldown = 1;
 		}
 
-		public override void OnSpawn(IEntitySource source)
-		{
-			Projectile.timeLeft = (int)(Owner.HeldItem.useAnimation * (1f / Owner.GetTotalAttackSpeed(DamageClass.Melee)));
-			maxTimeLeft = Projectile.timeLeft;
-		}
-
 		public override void AI()
 		{
+			if (!isInitialized)
+			{
+				isInitialized = true;
+				Projectile.timeLeft = (int)(Owner.HeldItem.useAnimation * (1f / Owner.GetTotalAttackSpeed(DamageClass.Melee)));
+				maxTimeLeft = Projectile.timeLeft;
+			}
+
 			Owner.heldProj = Projectile.whoAmI;
 			Owner.itemTime = Owner.itemAnimation = 2;
 
@@ -301,13 +311,16 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 			if (!fading)
 			{
+				Owner.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+				controlsPlayer.mouseRotationListener = true;
+
 				float totalTime = maxTimeLeft * 0.2f; //total amount of frames the stab lasts
 
 				if (stabTimer < totalTime)
 				{
 					if (stabTimer == 1) //things are initialized here each stab, such as the random rotation, and the randomness of the length of the stab
 					{
-						Projectile.velocity = Owner.DirectionTo(Main.MouseWorld).RotatedByRandom(0.35f);
+						Projectile.velocity = Owner.DirectionTo(controlsPlayer.mouseWorld).RotatedByRandom(0.35f);
 						stabVec = new Vector2(Main.rand.NextFloat(90, 150), 0);
 						hitNPCs.Clear();
 					}
@@ -347,13 +360,13 @@ namespace StarlightRiver.Content.Items.Gravedigger
 				if (Main.rand.NextBool(5))
 				{
 					var pos = Vector2.Lerp(Owner.Center, Projectile.Center, Main.rand.NextFloat());
-					Dust.NewDustPerfect(pos, ModContent.DustType<Dusts.GlowFastDecelerate>(), pos.DirectionTo(Main.MouseWorld).RotatedByRandom(0.35f) * Main.rand.NextFloat(2f, 5f), 0, new Color(255, 0, 0, 100), 0.45f);
+					Dust.NewDustPerfect(pos, ModContent.DustType<Dusts.GlowFastDecelerate>(), pos.DirectionTo(controlsPlayer.mouseWorld).RotatedByRandom(0.35f) * Main.rand.NextFloat(2f, 5f), 0, new Color(255, 0, 0, 100), 0.45f);
 				}
 
 				if (Main.rand.NextBool(5))
 				{
 					var pos = Vector2.Lerp(Owner.Center, Projectile.Center, Main.rand.NextFloat());
-					Dust.NewDustPerfect(pos, ModContent.DustType<Dusts.GlowLineFast>(), pos.DirectionTo(Main.MouseWorld).RotatedByRandom(0.35f) * Main.rand.NextFloat(2f, 5f), 0, new Color(255, 0, Main.rand.Next(255), 100), 1.25f);
+					Dust.NewDustPerfect(pos, ModContent.DustType<Dusts.GlowLineFast>(), pos.DirectionTo(controlsPlayer.mouseWorld).RotatedByRandom(0.35f) * Main.rand.NextFloat(2f, 5f), 0, new Color(255, 0, Main.rand.Next(255), 100), 1.25f);
 				}
 
 				if (!Owner.channel && amountStabs > 5 && Projectile.timeLeft == maxTimeLeft)
@@ -491,6 +504,8 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 		public List<Vector2> teleportPositions = new();
 
+		private bool isInitialized = false;
+
 		public Player Owner => Main.player[Projectile.owner];
 
 		public override string Texture => AssetDirectory.MiscItem + "RadculasRapier_Spear";
@@ -521,6 +536,12 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 		public override void AI()
 		{
+			if (!isInitialized)
+			{
+				Initialize();
+				isInitialized = true;
+			}
+
 			Projectile.Center = Owner.MountedCenter;
 
 			Owner.heldProj = Projectile.whoAmI;
@@ -564,9 +585,12 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			}
 		}
 
-		public override void OnSpawn(IEntitySource source)
+		private void Initialize()
 		{
 			RadculasRapierPlayer mp = Owner.GetModPlayer<RadculasRapierPlayer>();
+
+			Owner.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+			controlsPlayer.mouseListener = true;
 
 			originalPos = Owner.Center;
 
@@ -576,9 +600,9 @@ namespace StarlightRiver.Content.Items.Gravedigger
 
 			originalRot = Projectile.rotation;
 
-			Vector2 teleportPos = Owner.Center + Owner.DirectionTo(Main.MouseWorld) * 250f;
+			Vector2 teleportPos = Owner.Center + Owner.DirectionTo(controlsPlayer.mouseWorld) * 250f;
 
-			Tile tile = Main.tile[(int)Main.MouseWorld.X / 16, (int)Main.MouseWorld.Y / 16];
+			Tile tile = Main.tile[(int)controlsPlayer.mouseWorld.X / 16, (int)controlsPlayer.mouseWorld.Y / 16];
 
 			if (!Collision.CanHitLine(Owner.Center, 1, 1, teleportPos, 3, 3) || tile.HasTile && Main.tileSolid[tile.TileType] && !TileID.Sets.Platforms[tile.TileType])
 			{
@@ -616,7 +640,7 @@ namespace StarlightRiver.Content.Items.Gravedigger
 			if (tile.HasTile && Main.tileSolid[tile.TileType] && !TileID.Sets.Platforms[tile.TileType]) //additional check for player teleporting inside of a wall somehow (seemed to be caused by slopes)
 				Owner.position -= new Vector2(0f, Owner.height);
 
-			Owner.velocity += originalPos.DirectionTo(Main.MouseWorld) * 6.5f;
+			Owner.velocity += originalPos.DirectionTo(controlsPlayer.mouseWorld) * 6.5f;
 
 			teleported = true;
 

--- a/Content/Items/Haunted/Weapons.HauntedDaggerStaff.cs
+++ b/Content/Items/Haunted/Weapons.HauntedDaggerStaff.cs
@@ -1,7 +1,11 @@
-﻿using StarlightRiver.Content.Buffs.Summon;
+﻿using NetEasy;
+using StarlightRiver.Content.Buffs.Summon;
+using StarlightRiver.Content.Items.BarrierDye;
+using StarlightRiver.Core.Systems.BarrierSystem;
 using StarlightRiver.Core.Systems.CameraSystem;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -88,21 +92,32 @@ namespace StarlightRiver.Content.Items.Haunted
 
 		public int GetDaggerCount(NPC npc)
 		{
-			return Main.projectile.Where(p => p.active && p.type == ModContent.ProjectileType<HauntedDaggerProjectile>() && (p.ModProjectile as HauntedDaggerProjectile).TargetWhoAmI == npc.whoAmI && (p.ModProjectile as HauntedDaggerProjectile).Embedded).Count();
+			return Main.projectile.Where(p => p.active && p.type == ModContent.ProjectileType<HauntedDaggerProjectile>() && (p.ModProjectile as HauntedDaggerProjectile).TargetWhoAmI == npc.whoAmI && (p.ModProjectile as HauntedDaggerProjectile).embedded).Count();
 		}
 
-		public void UnembedDaggers(NPC npc, int count, Player strikingPlayer)
+		public static void UnembedDaggers(NPC npc, int count, Player strikingPlayer)
 		{
+			if (Main.myPlayer == strikingPlayer.whoAmI && Main.netMode == NetmodeID.MultiplayerClient)
+			{
+				var packet = new UnembedPacket(npc, strikingPlayer);
+				packet.Send(-1, strikingPlayer.whoAmI, false);
+			}
+
 			for (int i = 0; i < Main.maxProjectiles; i++)
 			{
 				Projectile proj = Main.projectile[i];
 				var dagger = proj.ModProjectile as HauntedDaggerProjectile;
 
-				if (proj.active && dagger != null && dagger.TargetWhoAmI == npc.whoAmI && dagger.Embedded)
+				if (proj.active && dagger != null && dagger.TargetWhoAmI == npc.whoAmI && dagger.embedded)
 					dagger.Unembed(false, npc);
 			}
 
-			npc.SimpleStrikeNPC(count * 10, 0, false, 0, DamageClass.Summon, true, strikingPlayer.luck);
+			if (strikingPlayer.whoAmI == Main.myPlayer) // Only player with the whip does the damage and gets the shake
+			{
+				npc.SimpleStrikeNPC(count * 10, 0, false, 0, DamageClass.Summon, true, strikingPlayer.luck);
+
+				CameraSystem.shake += 8;
+			}
 
 			bool fleshy = Helpers.Helper.IsFleshy(npc);
 
@@ -136,8 +151,6 @@ namespace StarlightRiver.Content.Items.Haunted
 					Main.rand.NextVector2Circular(10f, 10f), 0, new Color(150, 80, 30), 0.5f);
 				}
 			}
-
-			CameraSystem.shake += 8;
 		}
 
 		public override void OnHitByProjectile(NPC npc, Projectile projectile, NPC.HitInfo hit, int damageDone)
@@ -165,7 +178,6 @@ namespace StarlightRiver.Content.Items.Haunted
 	{
 		public const int MAX_ATTACK_DELAY = 5;
 
-		public int attackTimer;
 		public int rotTimer;
 		public int lifetime;
 
@@ -173,9 +185,12 @@ namespace StarlightRiver.Content.Items.Haunted
 
 		public Vector2 enemyOffset;
 
-		public NPC EmbeddedTarget;
+		public NPC embeddedTarget;
 
-		public bool Embedded => Projectile.ai[0] != 0f;
+		public bool embedded = false;
+
+
+		public ref float AttackTimer => ref Projectile.ai[0];
 		public ref float TargetWhoAmI => ref Projectile.ai[1];
 		public ref float AttackDelay => ref Projectile.ai[2];
 
@@ -248,15 +263,15 @@ namespace StarlightRiver.Content.Items.Haunted
 
 		public override bool PreAI()
 		{
-			if (Embedded)
+			if (embedded)
 			{
-				Projectile.position = EmbeddedTarget.position + enemyOffset;
+				Projectile.position = embeddedTarget.position + enemyOffset;
 
-				bool wrongTarget = MinionTarget != null && EmbeddedTarget != MinionTarget;
-				bool deadTarget = !EmbeddedTarget.active;
+				bool wrongTarget = MinionTarget != null && embeddedTarget != MinionTarget;
+				bool deadTarget = !embeddedTarget.active;
 
 				if (wrongTarget || deadTarget)
-					Unembed(wrongTarget && !deadTarget, EmbeddedTarget);
+					Unembed(wrongTarget && !deadTarget, embeddedTarget);
 
 				UpdateProjectileLifetime();
 
@@ -304,15 +319,15 @@ namespace StarlightRiver.Content.Items.Haunted
 			}
 			else if (AttackDelay <= 0)
 			{
-				attackTimer++;
+				AttackTimer++;
 
-				if (attackTimer < 45)
+				if (AttackTimer < 45)
 				{
 					DoIdleMovement();
 
-					rotTimer += (int)MathHelper.Lerp(1f, 50f, EaseFunction.EaseCubicIn.Ease(attackTimer / 45f));
+					rotTimer += (int)MathHelper.Lerp(1f, 50f, EaseFunction.EaseCubicIn.Ease(AttackTimer / 45f));
 
-					float lerper = MathHelper.Lerp(30f, 2f, EaseFunction.EaseCubicIn.Ease(attackTimer / 45f));
+					float lerper = MathHelper.Lerp(30f, 2f, EaseFunction.EaseCubicIn.Ease(AttackTimer / 45f));
 					if (Main.rand.NextBool(3))
 						Dust.NewDustPerfect(Projectile.Center + Main.rand.NextVector2CircularEdge(lerper, lerper), ModContent.DustType<Dusts.GlowFastDecelerate>(), Main.rand.NextVector2Circular(0.25f, 0.25f), 0, new Color(70, 200, 100), 0.5f);
 				}
@@ -327,7 +342,7 @@ namespace StarlightRiver.Content.Items.Haunted
 					rotationalVelocity = Vector2.Lerp(rotationalVelocity, Projectile.DirectionTo(Target.Center), 0.15f);
 					Projectile.rotation = rotationalVelocity.ToRotation() + MathHelper.PiOver2;
 
-					if (attackTimer == 45)
+					if (AttackTimer == 45)
 					{
 						Projectile.velocity += Projectile.DirectionTo(Target.Center) * 22f;
 
@@ -347,19 +362,21 @@ namespace StarlightRiver.Content.Items.Haunted
 				{
 					TargetWhoAmI = -1;
 					AttackDelay = MAX_ATTACK_DELAY;
-					attackTimer = 0;
+					AttackTimer = 0;
 				}
 			}
 		}
 
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			if (!Embedded && target.life > 0)
+			Owner.TryGetModPlayer(out StarlightPlayer starlightPlayer);
+			starlightPlayer.SetHitPacketStatus(shouldRunProjMethods: true);
+
+			if (!embedded && target.life > 0)
 			{
-				EmbeddedTarget = target;
-				Projectile.ai[0] = 1f;
+				embeddedTarget = target;
+				embedded = true;
 				Projectile.friendly = false;
-				Projectile.tileCollide = false;
 				enemyOffset = Projectile.position - target.position;
 				enemyOffset -= Projectile.velocity;
 				Projectile.netUpdate = true;
@@ -398,7 +415,7 @@ namespace StarlightRiver.Content.Items.Haunted
 
 		public override bool MinionContactDamage()
 		{
-			return !Embedded && AttackDelay <= 0 && attackTimer >= 45;
+			return !embedded && AttackDelay <= 0 && AttackTimer >= 45;
 		}
 
 		public override bool PreDraw(ref Color lightColor)
@@ -457,12 +474,12 @@ namespace StarlightRiver.Content.Items.Haunted
 			if (gNPC.UnembedCount <= 0)
 				gNPC.UnembedCount = count;
 
-			Projectile.ai[0] = 0f;
+			embedded = false;
 			TargetWhoAmI = -1f;
 			AttackDelay = MAX_ATTACK_DELAY;
 
 			Projectile.velocity *= -1f;
-			attackTimer = 0;
+			AttackTimer = 0;
 
 			for (int i = 0; i < 6; i++)
 			{
@@ -520,6 +537,57 @@ namespace StarlightRiver.Content.Items.Haunted
 		internal NPC FindTarget()
 		{
 			return Main.npc.Where(n => n.CanBeChasedBy() && n.Distance(Owner.Center) < 1000f).OrderBy(n => n.Distance(Projectile.Center)).FirstOrDefault();
+		}
+
+		public override void SendExtraAI(BinaryWriter writer)
+		{
+			writer.Write(embedded);
+			writer.WritePackedVector2(enemyOffset);
+
+			if (embeddedTarget != null)
+				writer.Write(embeddedTarget.whoAmI);
+			else
+				writer.Write(-1);
+		}
+
+		public override void ReceiveExtraAI(BinaryReader reader)
+		{
+			embedded = reader.ReadBoolean();
+			enemyOffset = reader.ReadPackedVector2();
+			int embeddedTargetId = reader.ReadInt32();
+
+			if (embeddedTargetId >= 0)
+				embeddedTarget = Main.npc[embeddedTargetId];
+			else 
+				embeddedTarget = null;
+		}
+	}
+
+	[Serializable]
+	public class UnembedPacket : Module
+	{
+		public readonly byte strikingPlayerWhoAmI;
+		public readonly int npcWhoAmI;
+
+		public UnembedPacket(NPC npc, Player strikingPlayer)
+		{
+			strikingPlayerWhoAmI = (byte)strikingPlayer.whoAmI;
+			npcWhoAmI = npc.whoAmI;
+		}
+
+		protected override void Receive()
+		{
+			Player player = Main.player[strikingPlayerWhoAmI];
+			NPC npc = Main.npc[npcWhoAmI];
+
+			// "Count" doesn't matter for the other players since only the striker deals damage
+			HauntedDaggerGlobalNPC.UnembedDaggers(npc, 0, player);
+
+			if (Main.netMode == NetmodeID.Server)
+			{
+				Send(-1, strikingPlayerWhoAmI, false);
+				return;
+			}
 		}
 	}
 }

--- a/Content/Items/Hell/Accessories.CharonsObol.cs
+++ b/Content/Items/Hell/Accessories.CharonsObol.cs
@@ -362,6 +362,9 @@ namespace StarlightRiver.Content.Items.Hell
 
 		private void ManageCaches()
 		{
+			if (Main.netMode == NetmodeID.Server)
+				return;
+
 			if (cache == null)
 			{
 				cache = new List<Vector2>();
@@ -378,6 +381,8 @@ namespace StarlightRiver.Content.Items.Hell
 
 		private void ManageTrail()
 		{
+			if (Main.netMode == NetmodeID.Server)
+				return;
 
 			trail ??= new Trail(Main.instance.GraphicsDevice, TRAILLENGTH, new NoTip(), factor => trailWidth * 3f, factor => TrailColor);
 

--- a/Content/Items/Manabonds/InfernalManabond.cs
+++ b/Content/Items/Manabonds/InfernalManabond.cs
@@ -91,6 +91,9 @@ namespace StarlightRiver.Content.Items.Manabonds
 			if (State == 1)
 				return;
 
+			Main.player[Projectile.owner].TryGetModPlayer(out StarlightPlayer starlightPlayer);
+			starlightPlayer.SetHitPacketStatus(shouldRunProjMethods: true);
+
 			target.AddBuff(BuffID.OnFire, 300);
 
 			Explode();
@@ -102,9 +105,6 @@ namespace StarlightRiver.Content.Items.Manabonds
 				return false;
 
 			Explode();
-
-			Main.player[Projectile.owner].TryGetModPlayer(out StarlightPlayer starlightPlayer);
-			starlightPlayer.SetHitPacketStatus(shouldRunProjMethods: true);
 
 			return false;
 		}

--- a/Content/Items/Misc/Weapons.CoachGun.cs
+++ b/Content/Items/Misc/Weapons.CoachGun.cs
@@ -253,8 +253,11 @@ namespace StarlightRiver.Content.Items.Misc
 				}
 			}
 
-			ManageCaches();
-			ManageTrail();
+			if (Main.netMode != NetmodeID.Server)
+			{
+				ManageCaches();
+				ManageTrail();
+			}
 		}
 
 		public override void Kill(int timeLeft)

--- a/Content/Items/Misc/Weapons.HeartStatueSentry.cs
+++ b/Content/Items/Misc/Weapons.HeartStatueSentry.cs
@@ -22,8 +22,8 @@ namespace StarlightRiver.Content.Items.Misc
 			Item.height = 32;
 			Item.value = Item.buyPrice(gold: 1);
 			Item.rare = ItemRarityID.Green;
-			Item.useTime = 10;
-			Item.useAnimation = 10;
+			Item.useTime = 30;
+			Item.useAnimation = 30;
 			Item.useStyle = ItemUseStyleID.Swing;
 			Item.DamageType = DamageClass.Summon;
 			Item.damage = 12;

--- a/Content/Items/Permafrost/Tools.TentacleHook.cs
+++ b/Content/Items/Permafrost/Tools.TentacleHook.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Terraria.ID;
+using static Humanizer.In;
 
 namespace StarlightRiver.Content.Items.Permafrost
 {
@@ -67,19 +68,22 @@ namespace StarlightRiver.Content.Items.Permafrost
 
 			if (launching)
 			{
+				Owner.TryGetModPlayer(out ControlsPlayer controlsPlayer);
+				controlsPlayer.mouseListener = true;
+
 				if (timer++ % 6 == 0)
 					followPoints.Add(Projectile.Center);
 
 				if (timer < 120)
 				{
-					if (Projectile.Distance(Main.MouseWorld) > 25)
+					if (Projectile.Distance(controlsPlayer.mouseWorld) > 25)
 					{
-						Projectile.velocity = Projectile.DirectionTo(Main.MouseWorld) * Projectile.velocity.Length();
+						Projectile.velocity = Projectile.DirectionTo(controlsPlayer.mouseWorld) * Projectile.velocity.Length();
 						stillTimer = 0;
 					}
 					else
 					{
-						Projectile.Center = Main.MouseWorld;
+						Projectile.Center = controlsPlayer.mouseWorld;
 						stillTimer++;
 						if (stillTimer > 15)
 							timer = 121;
@@ -87,7 +91,7 @@ namespace StarlightRiver.Content.Items.Permafrost
 				}
 				else
 				{
-					Projectile.velocity = Owner.DirectionTo(Main.MouseWorld) * Projectile.velocity.Length();
+					Projectile.velocity = Owner.DirectionTo(controlsPlayer.mouseWorld) * Projectile.velocity.Length();
 				}
 			}
 		}

--- a/Content/Items/Vitric/Weapons.CoachGunUpgrade.cs
+++ b/Content/Items/Vitric/Weapons.CoachGunUpgrade.cs
@@ -244,9 +244,9 @@ namespace StarlightRiver.Content.Items.Vitric
 			}
 		}
 
-		public override void Kill(int timeLeft)
+		public override void OnKill(int timeLeft)
 		{
-			Helper.PlayPitched("GlassMiniboss/GlassSmash", 0.3f, Main.rand.NextFloat(-0.1f, 0.1f), Projectile.position);
+			Helper.PlayPitched("GlassMiniboss/GlassSmash", 0.5f, Main.rand.NextFloat(-0.1f, 0.1f), Projectile.position);
 
 			for (int i = 1; i < 5; i++)
 			{

--- a/Content/Items/Vitric/Weapons.CoachGunUpgradeMiscProjectiles.cs
+++ b/Content/Items/Vitric/Weapons.CoachGunUpgradeMiscProjectiles.cs
@@ -46,7 +46,7 @@ namespace StarlightRiver.Content.Items.Vitric
 
 			Projectile.rotation = Projectile.velocity.ToRotation();
 
-			if (!Main.dedServ)
+			if (Main.netMode != NetmodeID.Server)
 			{
 				ManageCaches();
 				ManageTrail();
@@ -55,7 +55,7 @@ namespace StarlightRiver.Content.Items.Vitric
 			Dust.NewDustDirect(Projectile.position, Projectile.width, Projectile.height, ModContent.DustType<Dusts.Glow>(), 0f, 0f, 0, Color.DarkOrange, 0.35f);
 		}
 
-		public override void Kill(int timeLeft)
+		public override void OnKill(int timeLeft)
 		{
 			SoundEngine.PlaySound(SoundID.Shatter, Projectile.position);
 

--- a/Content/Items/Vitric/Weapons.VitricBow.cs
+++ b/Content/Items/Vitric/Weapons.VitricBow.cs
@@ -38,16 +38,14 @@ namespace StarlightRiver.Content.Items.Vitric
 			var aim = Vector2.Normalize(Main.MouseWorld - player.Center);
 
 			int proj = Projectile.NewProjectile(source, player.Center, (aim * 8.5f).RotatedBy(0.1f), type, damage, knockback, player.whoAmI);
-			Main.projectile[proj].scale = 0.5f;
-			Main.projectile[proj].damage /= 2;
+			Main.projectile[proj].scale = 0.5f; // Not synced. not sure how we would handle vanilla projectile manipulation sync
+			Main.projectile[proj].damage /= 2; // damage is synced implicitly since it's determined by the client on hit
 			Main.projectile[proj].noDropItem = true;
-			NetMessage.SendData(MessageID.SyncProjectile, -1, -1, null, proj);
 
 			int proj2 = Projectile.NewProjectile(source, player.Center, (aim * 8.5f).RotatedBy(-0.1f), type, damage, knockback, player.whoAmI);
 			Main.projectile[proj2].scale = 0.5f;
 			Main.projectile[proj2].damage /= 2;
 			Main.projectile[proj2].noDropItem = true;
-			NetMessage.SendData(MessageID.SyncProjectile, -1, -1, null, proj2);
 			return true;
 		}
 

--- a/Content/NPCs/Forest/Warbanner.cs
+++ b/Content/NPCs/Forest/Warbanner.cs
@@ -67,32 +67,35 @@ namespace StarlightRiver.Content.NPCs.Forest
 			NPC.chaseable = true;
 			NPC.value = 100;
 
-			chain = new RectangularBanner(15, false, NPC.Center + Vector2.UnitY * -40, 8)
+			if (Main.netMode != NetmodeID.Server)
 			{
-				constraintRepetitions = 2,
-				drag = 1.2f,
-				forceGravity = new Vector2(0f, 0.55f),
-				scale = 16f,
-				parent = NPC
-			};
+				chain = new RectangularBanner(15, false, NPC.Center + Vector2.UnitY * -40, 8)
+				{
+					constraintRepetitions = 2,
+					drag = 1.2f,
+					forceGravity = new Vector2(0f, 0.55f),
+					scale = 16f,
+					parent = NPC
+				};
 
-			miniChain0 = new RectangularBanner(10, false, NPC.Center + new Vector2(22, -48), 8)
-			{
-				constraintRepetitions = 2,
-				drag = 1.35f,
-				forceGravity = new Vector2(0f, 0.55f),
-				scale = 4f,
-				parent = NPC
-			};
+				miniChain0 = new RectangularBanner(10, false, NPC.Center + new Vector2(22, -48), 8)
+				{
+					constraintRepetitions = 2,
+					drag = 1.35f,
+					forceGravity = new Vector2(0f, 0.55f),
+					scale = 4f,
+					parent = NPC
+				};
 
-			miniChain1 = new RectangularBanner(10, false, NPC.Center + new Vector2(-22, -48), 8)
-			{
-				constraintRepetitions = 2,
-				drag = 1.35f,
-				forceGravity = new Vector2(0f, 0.55f),
-				scale = 4f,
-				parent = NPC
-			};
+				miniChain1 = new RectangularBanner(10, false, NPC.Center + new Vector2(-22, -48), 8)
+				{
+					constraintRepetitions = 2,
+					drag = 1.35f,
+					forceGravity = new Vector2(0f, 0.55f),
+					scale = 4f,
+					parent = NPC
+				};
+			}
 		}
 
 		public override void SetBestiary(BestiaryDatabase database, BestiaryEntry bestiaryEntry)

--- a/Content/NPCs/Misc/MagnetizedEnemy.cs
+++ b/Content/NPCs/Misc/MagnetizedEnemy.cs
@@ -75,9 +75,9 @@ namespace StarlightRiver.Content.NPCs.Misc
 				Vector2 dir = Main.rand.NextFloat(6.28f).ToRotationVector2();
 				Vector2 offset = Main.rand.NextBool(4) ? dir * Main.rand.NextFloat(30) : new Vector2(Main.rand.Next(-35, 35), npc.height / 2);
 
-				float smalLCharge = 0.5f;
+				float smallCharge = 0.5f;
 
-				var proj = Projectile.NewProjectileDirect(npc.GetSource_FromAI(), npc.Center + offset, dir.RotatedBy(Main.rand.NextFloat(-1, 1)) * 5, ModContent.ProjectileType<CloudstrikeShot>(), 0, 0, chargedPlayer.whoAmI, smalLCharge, 2);
+				var proj = Projectile.NewProjectileDirect(npc.GetSource_FromAI(), npc.Center + offset, dir.RotatedBy(Main.rand.NextFloat(-1, 1)) * 5, ModContent.ProjectileType<CloudstrikeShot>(), 0, 0, chargedPlayer.whoAmI, smallCharge, 2);
 				var mp = proj.ModProjectile as CloudstrikeShot;
 				mp.velocityMult = Main.rand.Next(1, 4);
 

--- a/Content/Tiles/VerletBanner.cs
+++ b/Content/Tiles/VerletBanner.cs
@@ -36,22 +36,28 @@ namespace StarlightRiver.Content.Tiles
 
 		public override void SafeSetDefaults()
 		{
-			Chain = new VerletChain(16, false, Center, 16)
+			if (Main.netMode != NetmodeID.Server)
 			{
-				constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
-				drag = 2f,//This number defaults to 1, Is very sensitive
-				forceGravity = new Vector2(0f, 0.25f),//gravity x/y
-				scale = 0.6f,
-				parent = this
-			};
+				Chain = new VerletChain(16, false, Center, 16)
+				{
+					constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
+					drag = 2f,//This number defaults to 1, Is very sensitive
+					forceGravity = new Vector2(0f, 0.25f),//gravity x/y
+					scale = 0.6f,
+					parent = this
+				};
+			}
 		}
 
 		public override void Update()
 		{
-			Chain.UpdateChain(Center);
+			if (Main.netMode != NetmodeID.Server)
+			{
+				Chain.UpdateChain(Center);
 
-			Chain.IterateRope(WindForce);
-			timer += 0.005f;
+				Chain.IterateRope(WindForce);
+				timer += 0.005f;
+			}
 		}
 
 		private void WindForce(int index)//wind

--- a/Content/Tiles/Vitric/RedBannerShort.cs
+++ b/Content/Tiles/Vitric/RedBannerShort.cs
@@ -30,22 +30,28 @@ namespace StarlightRiver.Content.Tiles.Vitric
 
 		public override void SafeSetDefaults()
 		{
-			Chain = new VerletChain(8, false, Center, 8)
+			if (Main.netMode != NetmodeID.Server)
 			{
-				constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
-				drag = 2f,//This number defaults to 1, Is very sensitive
-				forceGravity = new Vector2(0f, 0.3f),//gravity x/y
-				scale = 1.1f,
-				parent = this
-			};
+				Chain = new VerletChain(8, false, Center, 8)
+				{
+					constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
+					drag = 2f,//This number defaults to 1, Is very sensitive
+					forceGravity = new Vector2(0f, 0.3f),//gravity x/y
+					scale = 1.1f,
+					parent = this
+				};
+			}
 		}
 
 		public override void Update()
 		{
-			Chain.UpdateChain(Center);
+			if (Main.netMode != NetmodeID.Server)
+			{
+				Chain.UpdateChain(Center);
 
-			Chain.IterateRope(WindForce);
-			timer += 0.005f;
+				Chain.IterateRope(WindForce);
+				timer += 0.005f;
+			}
 		}
 
 		private void WindForce(int index)//wind

--- a/Content/Tiles/Vitric/Temple/LowWindBanner.cs
+++ b/Content/Tiles/Vitric/Temple/LowWindBanner.cs
@@ -41,27 +41,33 @@ namespace StarlightRiver.Content.Tiles.Vitric.Temple
 
 		public override void SafeSetDefaults()
 		{
-			Chain = new RectangularBanner(16, false, Center - Vector2.UnitY * 90, 8)
+			if (Main.netMode != NetmodeID.Server)
 			{
-				constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
-				drag = 2f,//This number defaults to 1, Is very sensitive
-				forceGravity = new Vector2(0f, 1.25f),//gravity x/y
-				scale = 15.0f,
-				parent = this
-			};
+				Chain = new RectangularBanner(16, false, Center - Vector2.UnitY * 90, 8)
+				{
+					constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
+					drag = 2f,//This number defaults to 1, Is very sensitive
+					forceGravity = new Vector2(0f, 1.25f),//gravity x/y
+					scale = 15.0f,
+					parent = this
+				};
+			}
 		}
 
 		public override void Update()
 		{
-			Chain.UpdateChain(Center - Vector2.UnitY * 90);
-			Chain.IterateRope(WindForce);
+			if (Main.netMode != NetmodeID.Server)
+			{
+				Chain.UpdateChain(Center - Vector2.UnitY * 90);
+				Chain.IterateRope(WindForce);
 
-			timer += 0.005f;
+				timer += 0.005f;
 
-			if (blow > 0)
-				blow--;
-			else if (blow < 0)
-				blow++;
+				if (blow > 0)
+					blow--;
+				else if (blow < 0)
+					blow++;
+			}
 		}
 
 		public override void Collision(Player Player)

--- a/Content/Tiles/Vitric/VitricBannerSmall.cs
+++ b/Content/Tiles/Vitric/VitricBannerSmall.cs
@@ -29,22 +29,28 @@ namespace StarlightRiver.Content.Tiles.Vitric
 
 		public override void SafeSetDefaults()
 		{
-			Chain = new VerletChain(8, false, Center, 8)
+			if (Main.netMode != NetmodeID.Server)
 			{
-				constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
-				drag = 2f,//This number defaults to 1, Is very sensitive
-				forceGravity = new Vector2(0f, 0.3f),//gravity x/y
-				scale = 1.1f,
-				parent = this
-			};
+				Chain = new VerletChain(8, false, Center, 8)
+				{
+					constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
+					drag = 2f,//This number defaults to 1, Is very sensitive
+					forceGravity = new Vector2(0f, 0.3f),//gravity x/y
+					scale = 1.1f,
+					parent = this
+				};
+			}
 		}
 
 		public override void Update()
 		{
-			Chain.UpdateChain(Center);
+			if (Main.netMode != NetmodeID.Server)
+			{
+				Chain.UpdateChain(Center);
 
-			Chain.IterateRope(WindForce);
-			timer += 0.005f;
+				Chain.IterateRope(WindForce);
+				timer += 0.005f;
+			}
 		}
 
 		private void WindForce(int index)//wind

--- a/Content/Tiles/VitricBanner.cs
+++ b/Content/Tiles/VitricBanner.cs
@@ -37,21 +37,27 @@ namespace StarlightRiver.Content.Tiles
 
 		public override void SafeSetDefaults()
 		{
-			Chain = new TriangularBanner(16, false, Center, 16)
+			if (Main.netMode != NetmodeID.Server)
 			{
-				constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
-				drag = 2f,//This number defaults to 1, Is very sensitive
-				forceGravity = new Vector2(0f, 0.25f),//gravity x/y
-				scale = 0.6f
-			};
+				Chain = new TriangularBanner(16, false, Center, 16)
+				{
+					constraintRepetitions = 2,//defaults to 2, raising this lowers stretching at the cost of performance
+					drag = 2f,//This number defaults to 1, Is very sensitive
+					forceGravity = new Vector2(0f, 0.25f),//gravity x/y
+					scale = 0.6f
+				};
+			}
 		}
 
 		public override void Update()
 		{
-			Chain.UpdateChain(Center);
-			Chain.IterateRope(WindForce);
+			if (Main.netMode != NetmodeID.Server)
+			{
+				Chain.UpdateChain(Center);
+				Chain.IterateRope(WindForce);
 
-			timer += 0.005f;
+				timer += 0.005f;
+			}
 		}
 
 		private void WindForce(int index)//wind

--- a/Core/ResourceReservationPlayer.cs
+++ b/Core/ResourceReservationPlayer.cs
@@ -84,8 +84,17 @@ namespace StarlightRiver.Core
 			if (Main.ResourceSetsManager.ActiveSetKeyName == "New")
 				DrawReservedManaFancy();
 
+			if (Main.ResourceSetsManager.ActiveSetKeyName == "NewWithText")
+				DrawReservedManaFancy();
+
 			if (Main.ResourceSetsManager.ActiveSetKeyName == "HorizontalBars")
-				DrawReservedManaBars();
+				DrawReservedManaBars(48f);
+
+			if (Main.ResourceSetsManager.ActiveSetKeyName == "HorizontalBarsWithText")
+				DrawReservedManaBars(52.5f);
+
+			if (Main.ResourceSetsManager.ActiveSetKeyName == "HorizontalBarsWithFullText")
+				DrawReservedManaBars(50f);
 		}
 
 		private void DrawReservedLife()
@@ -100,11 +109,17 @@ namespace StarlightRiver.Core
 			{
 				Vector2 pos = Vector2.Zero;
 
-				if (Main.ResourceSetsManager.ActiveSetKeyName == "HorizontalBars")
+				if (Main.ResourceSetsManager.ActiveSetKeyName == "HorizontalBars" || Main.ResourceSetsManager.ActiveSetKeyName == "HorizontalBarsWithText" || Main.ResourceSetsManager.ActiveSetKeyName == "HorizontalBarsWithFullText")
 				{
 					Texture2D texBar = ModContent.Request<Texture2D>(AssetDirectory.GUI + "ReservedBar").Value;
+					float yOffset = 24f;
+					
+					if (Main.ResourceSetsManager.ActiveSetKeyName == "HorizontalBarsWithText")
+						yOffset = 28f;
+					else if (Main.ResourceSetsManager.ActiveSetKeyName == "HorizontalBarsWithFullText")
+						yOffset = 26f;
 
-					pos = new Vector2(Main.screenWidth - 60 - vanillaHearts * 12 + k * 12, 24f);
+					pos = new Vector2(Main.screenWidth - 60 - vanillaHearts * 12 + k * 12, yOffset);
 
 					int width2 = 0;
 
@@ -141,6 +156,13 @@ namespace StarlightRiver.Core
 				else if (Main.ResourceSetsManager.ActiveSetKeyName == "New")
 				{
 					pos = new Vector2(Main.screenWidth - 76 - k * 24, 47f);
+
+					if (k >= 10)
+						pos += new Vector2(240, -28);
+				}
+				else if (Main.ResourceSetsManager.ActiveSetKeyName == "NewWithText")
+				{
+					pos = new Vector2(Main.screenWidth - 76 - k * 24, 52f);
 
 					if (k >= 10)
 						pos += new Vector2(240, -28);
@@ -241,7 +263,7 @@ namespace StarlightRiver.Core
 			}
 		}
 
-		private void DrawReservedManaBars()
+		private void DrawReservedManaBars(float yOffset)
 		{
 			Player player = Main.LocalPlayer;
 
@@ -251,7 +273,7 @@ namespace StarlightRiver.Core
 			for (int k = 0; k <= fullStarsToDraw; k++)
 			{
 				Texture2D texBar = ModContent.Request<Texture2D>(AssetDirectory.GUI + "ReservedBar").Value;
-				var pos = new Vector2(Main.screenWidth - 70 - vanillaStars * 12 + k * 12, 48f);
+				var pos = new Vector2(Main.screenWidth - 70 - vanillaStars * 12 + k * 12, yOffset);
 
 				int width2 = 0;
 

--- a/Core/StarlightPlayer.Events.cs
+++ b/Core/StarlightPlayer.Events.cs
@@ -254,8 +254,30 @@ namespace StarlightRiver.Core
 			orig(player, sItem, target, ref modifiers);
 		}
 
+		/// <summary>
+		/// This load creates a hook into the beginning of a hit processing so we can snapshot the initial state 
+		/// to send a packet to other clients and server to have them process all the custom onhit logic too where needed
+		/// </summary>
 		public override void Load()
 		{
+			//Order of operations for processing a projectile hit is as follows:
+			// 1. ProjectileLoader.ModifyHitNPC (event in StarlightProjectile.Events)
+			// 2. NPCLoader.ModifyHitByProjectile (event in StarlightNPC.Events) 
+			// 3. PlayerLoader.ModifyHitNPCWithProj (event in this class) <-- only if projectile has a player owner, will be skipped for server projs
+			// 4. ProjectileLoader.OnHitNPC (event in StarlightProjectile.Events)
+			// 5. NPCLoader.OnHitByProjectile (event in StarlightNPC.Events)
+			// 6. PlayerLoader.OnHitNPCWithProj (Event in this class) <-- only if projectile has a player owner, will be skipped for server projs
+
+			//order of operations for processing an item hit (true melee) is as follows
+			// 1. ItemLoader.ModifyHitNPC (event in StarlightItem.Events)
+			// 2. NPCLoader.ModifyHitByItem (event in StarlightNPC.Events)
+			// 3. PlayerLoader.ModifyHitNPCWithItem (event in this class)
+			// 4. ItemLoader.OnHitNPC (event in StarlightItem.Events)
+			// 5. NPCLoader.OnHitByItem (event in StarlightNPC.Events)
+			// 6. PlayerLoader.OnHitNPCWithItem (event in this class)
+
+			//No guarantees on ordering within each step unless we write something for that (probably not needed, just use the right event?)
+
 			MethodInfo ModifyHitNPCWithProjMethod = typeof(CombinedHooks).GetMethod("ModifyHitNPCWithProj", BindingFlags.Public | BindingFlags.Static);
 			ModifyHitNPCWithProjHook = new Hook(ModifyHitNPCWithProjMethod, OnModifyHitNPCWithProj);
 

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -22,6 +22,7 @@
 _ Visual sync for Tombsmasher
 - Haunted dagger staff functional in mp
 - Tentacle hook visual sync
+- Infernal manabond onhit visual sync
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -6,6 +6,7 @@
 - Defense System's radial selector no longer draws for other players in multiplayer
 - Defense system now deals summon damage
 - Breach Cannon now mostly works in multiplayer
+- Supply Beacon no longer spawns extras in multiplayer
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -14,9 +14,11 @@
 - Fix for pirate chest in multiplayer
 - Visual sync for sandscript
 - Cloudstrike functional in mp
+- Skullbuster mp fixes
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively
 - Upped Defense system and heart statue usetime to match all other sentries
 - Seaglass Lens now deals real crits that can benefit from other accessories instead of non-scaling phantom crits
 - Breach Cannon now has Id based Iframes and no longer blocks other weapons from dealing damage
+- Skullbuster bombs now use local Iframes

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -20,6 +20,7 @@
 - Radculas Rapier mp fixes
 - Bloodbolter functional in mp
 _ Visual sync for Tombsmasher
+- Haunted dagger staff functional in mp
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -21,6 +21,7 @@
 - Bloodbolter functional in mp
 _ Visual sync for Tombsmasher
 - Haunted dagger staff functional in mp
+- Tentacle hook visual sync
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -16,6 +16,7 @@
 - Cloudstrike functional in mp
 - Skullbuster mp fixes
 - Blood Amulet functional in mp
+- Radculas Rapier mp fixes
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -9,6 +9,7 @@
 - Supply Beacon no longer spawns extras in multiplayer
 - Supply Beacon now has buff icons
 - Fix for Archaeologist Whip's treasure drops in multiplayer
+- Fix for pirate chest in multiplayer
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -24,6 +24,7 @@ _ Visual sync for Tombsmasher
 - Tentacle hook visual sync
 - Infernal manabond onhit visual sync
 - Fix missing graphics device for coach gun
+- Maneater pot visual sync
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -2,14 +2,17 @@
 
 ## Fixes
 - Fixed Face Steak dropping from Eater of Souls (now drops from Face Monsters)
+- Defense system now deals summon damage
+- Supply Beacon now has buff icons
+
+## Multiplayer
 - Fixed amulet of the bloodless warrior making you appear dead in multiplayer
 - Defense System's radial selector no longer draws for other players in multiplayer
-- Defense system now deals summon damage
 - Breach Cannon now mostly works in multiplayer
 - Supply Beacon no longer spawns extras in multiplayer
-- Supply Beacon now has buff icons
 - Fix for Archaeologist Whip's treasure drops in multiplayer
 - Fix for pirate chest in multiplayer
+- Visual sync for sandscript
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -15,6 +15,7 @@
 - Visual sync for sandscript
 - Cloudstrike functional in mp
 - Skullbuster mp fixes
+- Blood Amulet functional in mp
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively
@@ -22,3 +23,4 @@
 - Seaglass Lens now deals real crits that can benefit from other accessories instead of non-scaling phantom crits
 - Breach Cannon now has Id based Iframes and no longer blocks other weapons from dealing damage
 - Skullbuster bombs now use local Iframes
+- Blood Amulet now uses local Iframes

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -5,8 +5,10 @@
 - Fixed amulet of the bloodless warrior making you appear dead in multiplayer
 - Defense System's radial selector no longer draws for other players in multiplayer
 - Defense system now deals summon damage
+- Breach Cannon now mostly works in multiplayer
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively
 - Upped Defense system and heart statue usetime to match all other sentries
 - Seaglass Lens now deals real crits that can benefit from other accessories instead of non-scaling phantom crits
+- Breach Cannon now has Id based Iframes and no longer blocks other weapons from dealing damage

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -13,6 +13,7 @@
 - Fix for Archaeologist Whip's treasure drops in multiplayer
 - Fix for pirate chest in multiplayer
 - Visual sync for sandscript
+- Cloudstrike functional in mp
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -5,6 +5,7 @@
 - Defense system now deals summon damage
 - Supply Beacon now has buff icons
 - Resource reservation overlays now draw for the new interfaces with numbers
+- Shine staff no longer stacks mana regen delay penalty for repeated use
 
 ## Multiplayer
 - Fixed amulet of the bloodless warrior making you appear dead in multiplayer
@@ -25,6 +26,7 @@ _ Visual sync for Tombsmasher
 - Infernal manabond onhit visual sync
 - Fix missing graphics device for coach gun
 - Maneater pot visual sync
+- Shine staff visual sync
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -4,6 +4,7 @@
 - Fixed Face Steak dropping from Eater of Souls (now drops from Face Monsters)
 - Defense system now deals summon damage
 - Supply Beacon now has buff icons
+- Resource reservation overlays now draw for the new interfaces with numbers
 
 ## Multiplayer
 - Fixed amulet of the bloodless warrior making you appear dead in multiplayer

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -4,6 +4,7 @@
 - Fixed Face Steak dropping from Eater of Souls (now drops from Face Monsters)
 - Fixed amulet of the bloodless warrior making you appear dead in multiplayer
 - Defense System's radial selector no longer draws for other players in multiplayer
+- Defense system now deals summon damage
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -23,6 +23,7 @@ _ Visual sync for Tombsmasher
 - Haunted dagger staff functional in mp
 - Tentacle hook visual sync
 - Infernal manabond onhit visual sync
+- Fix missing graphics device for coach gun
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -9,3 +9,4 @@
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively
 - Upped Defense system and heart statue usetime to match all other sentries
+- Seaglass Lens now deals real crits that can benefit from other accessories instead of non-scaling phantom crits

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -6,3 +6,4 @@
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively
+- Upped Defense system and heart statue usetime to match all other sentries

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -3,6 +3,7 @@
 ## Fixes
 - Fixed Face Steak dropping from Eater of Souls (now drops from Face Monsters)
 - Fixed amulet of the bloodless warrior making you appear dead in multiplayer
+- Defense System's radial selector no longer draws for other players in multiplayer
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -18,6 +18,7 @@
 - Blood Amulet functional in mp
 - Radculas Rapier mp fixes
 - Bloodbolter functional in mp
+_ Visual sync for Tombsmasher
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -7,6 +7,7 @@
 - Defense system now deals summon damage
 - Breach Cannon now mostly works in multiplayer
 - Supply Beacon no longer spawns extras in multiplayer
+- Fix for Archaeologist Whip's treasure drops in multiplayer
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -17,6 +17,7 @@
 - Skullbuster mp fixes
 - Blood Amulet functional in mp
 - Radculas Rapier mp fixes
+- Bloodbolter functional in mp
 
 ## Tweaks
 - Both Eater Steak and Face Steak can now drop from Corruptors and Herplings respectively

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -7,6 +7,7 @@
 - Defense system now deals summon damage
 - Breach Cannon now mostly works in multiplayer
 - Supply Beacon no longer spawns extras in multiplayer
+- Supply Beacon now has buff icons
 - Fix for Archaeologist Whip's treasure drops in multiplayer
 
 ## Tweaks


### PR DESCRIPTION
I can't reproduce the softlocks that people have reported for the bossfights so instead I went through every obtainable item I'm aware of and checked them for mp compat. my hypothesis is that some other item / situation lead into the softlock failstate that people have reported. But since I haven't reproduced I really have no idea if thats the case.

Ideally we would have testers that would go through these items and report them so the devs don't have to iterate through everything like this but oh well. For example it would be nice if testers were to go though all the magic items in SLR and attempted to use them with the haunted armor in single and multiplayer to ensure it's robust. 

fixed a handful of obvious bugs in the process and set a few projectiles that would make sense to use local / Id iframes

these are the only related issues I see on github that will be resolved with this:
#653 #634 #633 