### PR TITLE
hardened dummy system for multiplayer

### DIFF
--- a/Content/Tiles/Vitric/DestructableGlass.cs
+++ b/Content/Tiles/Vitric/DestructableGlass.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ID;
+﻿using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace StarlightRiver.Content.Tiles.Vitric
 {
@@ -26,7 +27,6 @@ namespace StarlightRiver.Content.Tiles.Vitric
 			if (closer)
 			{
 				var hitbox = new Rectangle(i * 16, j * 16, 16, 16);
-				Rectangle hidebox = hitbox;
 
 				int speed = (int)Main.LocalPlayer.velocity.Length() * 2;
 
@@ -40,6 +40,15 @@ namespace StarlightRiver.Content.Tiles.Vitric
 				if (colliding)
 				{
 					WorldGen.KillTile(i, j);
+
+					// For a multplayer client, killTile doesn't spawn items so we'll spawn item ourselves and send a packet
+					if (Main.netMode == NetmodeID.MultiplayerClient)
+					{
+						int item = Item.NewItem(new EntitySource_TileBreak(i, j), new Vector2(i, j) * 16, ModContent.ItemType<Items.Vitric.VitricOre>(), 1);
+
+						NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item, 1f);
+					}
+
 					Framing.GetTileSafely(i, j).IsActuated = true;
 					NetMessage.SendTileSquare(Main.LocalPlayer.whoAmI, i, j);
 				}

--- a/Content/Tiles/Vitric/Temple/GearPuzzle/GearTile.cs
+++ b/Content/Tiles/Vitric/Temple/GearPuzzle/GearTile.cs
@@ -300,20 +300,50 @@ namespace StarlightRiver.Content.Tiles.Vitric.Temple.GearPuzzle
 
 		protected bool Engaged
 		{
-			get => GearEntity.engaged;
-			set => GearEntity.engaged = value;
+			get
+			{
+				if (GearEntity != null)
+					return GearEntity.engaged;
+
+				return false;
+			}
+			set
+			{
+				if (GearEntity != null)
+					GearEntity.engaged = value;
+			}
 		}
 
 		protected float RotationVelocity
 		{
-			get => GearEntity.rotationVelocity;
-			set => GearEntity.rotationVelocity = value;
+			get
+			{
+				if (GearEntity != null)
+					return GearEntity.rotationVelocity;
+
+				return 0;
+			}
+			set
+			{
+				if (GearEntity != null)
+					GearEntity.rotationVelocity = value;
+			}
 		}
 
 		protected float RotationOffset
 		{
-			get => GearEntity.rotationOffset;
-			set => GearEntity.rotationOffset = value;
+			get
+			{
+				if (GearEntity != null)
+					return GearEntity.rotationOffset;
+
+				return 0;
+			}
+			set
+			{
+				if (GearEntity != null)
+					GearEntity.rotationOffset = value;
+			}
 		}
 
 		protected GearTileEntity GearEntity

--- a/Core/Systems/DummyTileSystem/DummyTile.cs
+++ b/Core/Systems/DummyTileSystem/DummyTile.cs
@@ -104,7 +104,7 @@ namespace StarlightRiver.Core.Systems.DummyTileSystem
 		}
 
 		/// <summary>
-		/// searches through projectiles for a dummy that's not found in the dictionary, and adds it to the dictionary if found
+		/// searches through dummy entities for a dummy that's not found in the dictionary, and adds it to the dictionary if found
 		/// primarily for multiplayer since its more likely to fail to be attached to a key there
 		/// </summary>
 		/// <param name="i"></param>

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -7,6 +7,7 @@
 - Resource reservation overlays now draw for the new interfaces with numbers
 - Shine staff no longer stacks mana regen delay penalty for repeated use
 - Using Main.DefaultSamplerState for spritebatches to avoid some blurry sprites
+- Fixed gear puzzle crash
 
 ## Multiplayer
 - Fixed amulet of the bloodless warrior making you appear dead in multiplayer
@@ -29,6 +30,8 @@ _ Visual sync for Tombsmasher
 - Maneater pot visual sync
 - Shine staff visual sync
 - Fixed auto-select being prevented from placing torches and throwing glowsticks
+- Hardened dummy system against players joining a world late
+- vitric ore dummies now properly remove themselves for clients
 
 ## Content
 - New enemy: Dreambeast


### PR DESCRIPTION
This fixes a few issues found with dummies in multiplayer. most specifically around late joins to a world now can receive dummy info and clients no longer send netupdates for the dummies.  Server now tells clients to delete dummies when they are set inactive