### PR TITLE
Fix major memory drains

### DIFF
--- a/Content/Tiles/Vitric/Temple/GearPuzzle/GearTile.cs
+++ b/Content/Tiles/Vitric/Temple/GearPuzzle/GearTile.cs
@@ -386,9 +386,6 @@ namespace StarlightRiver.Content.Tiles.Vitric.Temple.GearPuzzle
 
 		public override void Update()
 		{
-			if (GearEntity is null)
-				return;
-
 			if (gearAnimation > 0)
 				gearAnimation--;
 

--- a/Content/Tiles/Vitric/Temple/VitricTempleWall.cs
+++ b/Content/Tiles/Vitric/Temple/VitricTempleWall.cs
@@ -7,6 +7,9 @@ namespace StarlightRiver.Content.Tiles.Vitric.Temple
 {
 	class VitricTempleWall : ModWall
 	{
+		public static Texture2D CustomTexture = Request<Texture2D>(AssetDirectory.VitricTile + "VitricTempleWall").Value;
+		public static Texture2D CustomBackTexture = Request<Texture2D>(AssetDirectory.VitricTile + "VitricTempleWallEdge").Value;
+
 		public override string Texture => AssetDirectory.VitricTile + "VitricTempleWall";
 
 		public override void SetStaticDefaults()
@@ -30,9 +33,9 @@ namespace StarlightRiver.Content.Tiles.Vitric.Temple
 			Lighting.GetCornerColors(i, j, out VertexColors vertices);
 
 			if (!(frame2.Intersects(new Rectangle(36, 36, 36 * 3, 36)) || frame2.Intersects(new Rectangle(36 * 6, 36, 36 * 3, 36 * 2)) || frame2.Intersects(new Rectangle(36 * 10, 0, 36 * 2, 36 * 3))))
-				Main.tileBatch.Draw(Request<Texture2D>(Texture + "Edge").Value, new Vector2(i * 16 - (int)Main.screenPosition.X + Main.offScreenRange - 8, j * 16 - (int)Main.screenPosition.Y + Main.offScreenRange - 8), frame2, vertices, Vector2.Zero, 1f, SpriteEffects.None);
+				Main.tileBatch.Draw(CustomBackTexture, new Vector2(i * 16 - (int)Main.screenPosition.X + Main.offScreenRange - 8, j * 16 - (int)Main.screenPosition.Y + Main.offScreenRange - 8), frame2, vertices, Vector2.Zero, 1f, SpriteEffects.None);
 
-			Main.tileBatch.Draw(Request<Texture2D>(Texture).Value, new Vector2(i * 16 - (int)Main.screenPosition.X + Main.offScreenRange, j * 16 - (int)Main.screenPosition.Y + Main.offScreenRange), frame, vertices, Vector2.Zero, 1f, SpriteEffects.None);
+			Main.tileBatch.Draw(CustomTexture, new Vector2(i * 16 - (int)Main.screenPosition.X + Main.offScreenRange, j * 16 - (int)Main.screenPosition.Y + Main.offScreenRange), frame, vertices, Vector2.Zero, 1f, SpriteEffects.None);
 
 			return false;
 		}


### PR DESCRIPTION
Fixes 2 of the most dire memory consumers in the mod. Note, we really should move to caching any and all textures used for drawing as the string manipulation on Request is really memory hungry, ouch! Best thing is probably moving any instances of Request to be a static Asset in the file and then getting Asset.Value to draw dynamically. Probably automatable with a clever script (Get AI involved?)