### PR TITLE
fixes for cutaway and reflection target inverted gravity rendering

### DIFF
--- a/Core/Systems/ScreenTargetSystem/ScreenTargetHandler.cs
+++ b/Core/Systems/ScreenTargetSystem/ScreenTargetHandler.cs
@@ -112,7 +112,7 @@ namespace StarlightRiver.Core.Systems.ScreenTargetSystem
 				if (target.drawFunct is null) //allows for RTs which dont draw in the default loop, like the lighting tile buffers
 					continue;
 
-				Main.spriteBatch.Begin();
+				Main.spriteBatch.Begin(default, default, Main.DefaultSamplerState, default, RasterizerState.CullNone, default);
 				Main.graphics.GraphicsDevice.SetRenderTarget(target.RenderTarget);
 				Main.graphics.GraphicsDevice.Clear(Color.Transparent);
 

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -2,3 +2,4 @@
 
 ## Fixes
 - Fixed random invalid memory access crashes
+- Fixes for inverted gravity rendering


### PR DESCRIPTION
guessing these were broken during the migration to the new rendertarget system. fixes some issues with reflections and cutaways especially for inverted gravity