### PR TITLE
Updated dotnet path to support editors like Rider

### DIFF
--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -2,13 +2,13 @@
   "profiles": {
     "Terraria": {
       "commandName": "Executable",
-      "executablePath": "dotnet",
+      "executablePath": "$(DotNetName)",
       "commandLineArgs": "$(tMLPath)",
       "workingDirectory": "$(tMLSteamPath)"
     },
     "TerrariaServer": {
       "commandName": "Executable",
-      "executablePath": "dotnet",
+      "executablePath": "$(DotNetName)",
       "commandLineArgs": "$(tMLServerPath)",
       "workingDirectory": "$(tMLSteamPath)"
     }


### PR DESCRIPTION
Fixed not being able to build the solution using editors, such as JetBrains' Rider, which need the dotnet path to include the '.exe' extension in order to be recognized.

Relevant TML PR that fixed this issue:
tModLoader/tModLoader#3944