### PR TITLE
Improved Cough Drops proc behaviour and added damage buff

### DIFF
--- a/Content/Buffs/CoughDropsBuff.cs
+++ b/Content/Buffs/CoughDropsBuff.cs
@@ -9,6 +9,7 @@ namespace StarlightRiver.Content.Buffs
 		public override void Update(Player Player, ref int buffIndex)
 		{
 			Player.maxRunSpeed += 2;
+			Player.GetDamage(DamageClass.Generic) += 0.15f;
 		}
 	}
 }

--- a/Content/Items/Misc/Accessories.CoughDrops.cs
+++ b/Content/Items/Misc/Accessories.CoughDrops.cs
@@ -1,5 +1,6 @@
 ﻿using StarlightRiver.Content.Buffs;
 using StarlightRiver.Content.Items.BaseTypes;
+using Terraria.ID;
 
 namespace StarlightRiver.Content.Items.Misc
 {
@@ -21,7 +22,8 @@ namespace StarlightRiver.Content.Items.Misc
 
 		private void DelBuff(On_Player.orig_DelBuff orig, Player self, int buffId)
 		{
-			if (Main.debuff[self.buffType[buffId]] && Equipped(self))
+			int buffType = self.buffType[buffId];
+			if (Main.debuff[buffType] && !Main.buffNoTimeDisplay[buffType] && Equipped(self))
 				self.AddBuff(ModContent.BuffType<CoughDropsBuff>(), 180);
 
 			orig(self, buffId);

--- a/Content/Items/Misc/Accessories.CoughDrops.cs
+++ b/Content/Items/Misc/Accessories.CoughDrops.cs
@@ -23,7 +23,7 @@ namespace StarlightRiver.Content.Items.Misc
 		private void DelBuff(On_Player.orig_DelBuff orig, Player self, int buffId)
 		{
 			int buffType = self.buffType[buffId];
-			if (Main.debuff[buffType] && !Main.buffNoTimeDisplay[buffType] && Equipped(self))
+			if (Main.debuff[buffType] && !Main.buffNoTimeDisplay[buffType] && !BuffID.Sets.NurseCannotRemoveDebuff[buffType] && Equipped(self))
 				self.AddBuff(ModContent.BuffType<CoughDropsBuff>(), 180);
 
 			orig(self, buffId);


### PR DESCRIPTION
ba6f4918418e004f6b6953761d10f3d367cebb6f, f5a86aaba6786c17a1e4ff2fde20d7d4d4f8766a: Made the Cough Drops buff only activate if the removed debuff displays the duration and can be removed by the nurse. This mostly fixes issue #445.
c22c20a68c0fb4e25effe54b4240b403f889f6c5: Reintroduced 15% additive damage buff to Cough Drops debuff.