### PR TITLE
Vengeful Spirit, Living Blood, Haunted Set Tweaks

### DIFF
--- a/Content/Items/Gravedigger/Materials.LivingBlood.cs
+++ b/Content/Items/Gravedigger/Materials.LivingBlood.cs
@@ -29,7 +29,7 @@ namespace StarlightRiver.Content.Items.Gravedigger
 		{
 			if (npc.type == NPCID.BloodZombie || npc.type == NPCID.Drippler)
 			{
-				npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<LivingBlood>(), 6, 1, 3));
+				npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<LivingBlood>(), 5, 1, 4));
 			}
 		}
 	}

--- a/Content/Items/Haunted/Armors.PoltergeistArmor.cs
+++ b/Content/Items/Haunted/Armors.PoltergeistArmor.cs
@@ -1,6 +1,9 @@
-﻿using StarlightRiver.Content.Items.Gravedigger;
+﻿using Mono.Cecil;
+using StarlightRiver.Content.Items.Gravedigger;
 using System.Collections.Generic;
 using System.Linq;
+using Terraria.Audio;
+using Terraria.GameContent;
 using Terraria.ID;
 using static Terraria.ModLoader.ModContent;
 
@@ -12,6 +15,17 @@ namespace StarlightRiver.Content.Items.Haunted
 		public List<Projectile> minions = new();
 		public int timer;
 		public int sleepTimer;
+		public (string singular, string plural)[] minionBoredomMessages =
+		{
+			("Your _ seems bored...", "Your _ seem bored..."),
+			("Your _ lost interest...", "Your _ lost interest..."),
+			("Your _ is hanging limply...", "Your _ are hanging limply..."),
+			("Looks like your _ isn't feeling it...", "Looks like your _ aren't feeling it..."),
+			("Your _ is clearly unimpressed...", "Your _ are clearly unimpressed..."),
+			("It seems the magic is just gone for your _...", "It seems the magic is just gone for your _..."),
+			("Looks like your _ is totally checked out...", "Looks like your _ are totally checked out..."),
+			("Your _ is hovering aimlessly...", "Your _ are hovering aimlessly..."),
+		};
 
 		public override string Texture => AssetDirectory.HauntedItem + Name;
 
@@ -78,7 +92,17 @@ namespace StarlightRiver.Content.Items.Haunted
 			}
 
 			if (player == Main.LocalPlayer && sleepTimer == 1 && minions.Count > 0) //warning message
-				Main.NewText("Your haunted weapons seem bored...", new Color(200, 120, 255));
+			{
+				AdvancedPopupRequest request = default;
+				var message = minionBoredomMessages[Main.rand.Next(minionBoredomMessages.Length)];
+				request.Text = message.plural.Replace("_", "haunted weapons");
+				if (minions.Count == 1)
+					request.Text = message.singular.Replace("_", (minions.First().ModProjectile as PoltergeistMinion).Item.Name);
+				request.DurationInFrames = 180;
+				request.Color = new Color(200, 120, 255);
+				request.Velocity = new Vector2(0f, -4f);
+				PopupText.NewText(request, player.Top);
+			}
 
 			if (sleepTimer > 0) //decrement sleep timer
 				sleepTimer--;
@@ -115,6 +139,7 @@ namespace StarlightRiver.Content.Items.Haunted
 
 					helm.minions.Add(proj);
 					helm.sleepTimer = 1200;
+					SoundEngine.PlaySound(item.UseSound.Value with { Pitch = item.UseSound.Value.Pitch - 0.3f});
 				}
 			}
 

--- a/Content/NPCs/Misc/LootWraith.cs
+++ b/Content/NPCs/Misc/LootWraith.cs
@@ -316,7 +316,7 @@ namespace StarlightRiver.Content.NPCs.Misc
 
 		public override void ModifyNPCLoot(NPCLoot npcLoot)
 		{
-			npcLoot.Add(ItemDropRule.Common(ItemType<VengefulSpirit>(), 1, 2, 4));
+			npcLoot.Add(ItemDropRule.Common(ItemType<VengefulSpirit>(), 1, 4, 6));
 		}
 
 		private void UpdateChain()

--- a/Content/WorldGeneration/GenerateLootWraiths.cs
+++ b/Content/WorldGeneration/GenerateLootWraiths.cs
@@ -9,10 +9,10 @@ namespace StarlightRiver.Core
 		{
 			foreach (Chest chest in Main.chest)
 			{
-				if (chest != null && WorldGen.genRand.NextBool(8))
+				if (chest != null && WorldGen.genRand.NextBool(6))
 				{
 					int frameX = Framing.GetTileSafely(chest.x, chest.y).TileFrameX / 36;
-					if (frameX == 11 || frameX == 1)
+					if (frameX == 11 || frameX == 1) //Golden or Frozen Chests
 					{
 						var npc = NPC.NewNPCDirect(new EntitySource_Misc("Loot Wraith"), chest.x * 16, chest.y * 16, ModContent.NPCType<LootWraith>());
 						if (npc.ModNPC is LootWraith wraith)


### PR DESCRIPTION
-Made Loot Wraiths more common and drop more vengeful spirits
-Made Blood enemies drop living blood more frequently and in larger quantities
-Made Haunted Weapons play a noise when haunted
-Made Haunted Weapon text use a popup instead of a chat message, and added more messages for variety