### PR TITLE
Prevent cutaways in subworlds

### DIFF
--- a/Core/Systems/CutawaySystem/CutawayHandler.cs
+++ b/Core/Systems/CutawaySystem/CutawayHandler.cs
@@ -15,6 +15,10 @@ namespace StarlightRiver.Core.Systems.CutawaySystem
 		{
 			CutawayHook.cutaways.Clear();
 
+			// Dont create in subworlds
+			if (CutawayHook.InSubworld)
+				return;
+
 			// Auroracle temple overlay
 			cathedralOverlay = new Cutaway(ModContent.Request<Texture2D>("StarlightRiver/Assets/Bosses/SquidBoss/CathedralOver", ReLogic.Content.AssetRequestMode.ImmediateLoad).Value, StarlightWorld.squidBossArena.TopLeft() * 16)
 			{

--- a/Core/Systems/CutawaySystem/CutawayHook.cs
+++ b/Core/Systems/CutawaySystem/CutawayHook.cs
@@ -13,7 +13,12 @@ namespace StarlightRiver.Core.Systems.CutawaySystem
 
 		public static ScreenTarget cutawayTarget;
 
+		// We track this so we can disable these in subworlds
+		private static Mod subLib;
+
 		private static bool Inside => cutaways?.Any(n => n.fadeTime < 0.95f) ?? false;
+
+		public static bool InSubworld => (bool)(subLib?.Call("AnyActive") ?? false);
 
 		public override void Load()
 		{
@@ -22,6 +27,8 @@ namespace StarlightRiver.Core.Systems.CutawaySystem
 
 			cutaways = new();
 			cutawayTarget = new(DrawCutawayTarget, () => Inside, 1);
+
+			ModLoader.TryGetMod("SubworldLibrary", out subLib);
 
 			On_Main.DrawInfernoRings += DrawNegative;
 			On_Main.DrawDust += DrawPositive;
@@ -42,8 +49,11 @@ namespace StarlightRiver.Core.Systems.CutawaySystem
 
 		private void DrawPositive(On_Main.orig_DrawDust orig, Main self)
 		{
-			for (int k = 0; k < cutaways.Count; k++)
-				cutaways[k].Draw();
+			if (!InSubworld)
+			{
+				for (int k = 0; k < cutaways.Count; k++)
+					cutaways[k].Draw();
+			}
 
 			orig(self);
 		}
@@ -52,7 +62,7 @@ namespace StarlightRiver.Core.Systems.CutawaySystem
 		{
 			orig(self);
 
-			if (StarlightRiver.debugMode)
+			if (StarlightRiver.debugMode || InSubworld)
 				return;
 
 			if (Inside)

--- a/PATCH_NOTES.txt
+++ b/PATCH_NOTES.txt
@@ -37,6 +37,7 @@
 - Fixed an issue where all stackable buffs failed to sync in multiplayer
 - Fixed an issue where the cough drops did not grant a damage increase like the tooltip stated
 - Fixed the text card popup when gaining an ability not dissappearing sometimes
+- Fixed cutaways drawing in subworlds where they should not exist
 
 ## Boring programmer stuff
 - Keywords now utilize localization and are data driven similar to dialogue and hints


### PR DESCRIPTION
Adds a mod.call safety check for subworlds from subworld library to prevent the addition and rendering of cutaways that should not be present while in subworlds.

fixes https://github.com/ProjectStarlight/StarlightRiver/issues/782