### PR TITLE
Support Wikithis

### DIFF
--- a/Compat/Wikithis/WikithisWrapper.cs
+++ b/Compat/Wikithis/WikithisWrapper.cs
@@ -1,0 +1,20 @@
+﻿namespace StarlightRiver.Compat.Wikithis
+{
+	public static class WikithisWrapper
+	{
+		private const string STARLIGHT_RIVER_WIKI_URL = "https://starlightrivermod.wiki.gg/wiki/{}";
+
+		public static void AddStarlightRiverWikiUrl()
+		{
+			AddModUrl(STARLIGHT_RIVER_WIKI_URL);
+		}
+
+		public static void AddModUrl(string url)
+		{
+			if (ModLoader.TryGetMod("Wikithis", out Mod wikithis))
+			{
+				wikithis.Call("AddModUrl", StarlightRiver.Instance, url);
+			}
+		}
+	}
+}

--- a/StarlightRiver.cs
+++ b/StarlightRiver.cs
@@ -108,6 +108,7 @@ namespace StarlightRiver
 		public override void PostSetupContent()
 		{
 			Compat.BossChecklist.BossChecklistCalls.CallBossChecklist();
+			Compat.Wikithis.WikithisWrapper.AddStarlightRiverWikiUrl();
 
 			NetEasy.NetEasy.Register(this);
 


### PR DESCRIPTION
### What are the specifics of what is being added?
Support for [Wikithis](https://steamcommunity.com/sharedfiles/filedetails/?id=2832487441&searchtext=wikithis) such that you can however your cursor over any Starlight River item and press a configured button to swiftly open the corresponding wiki.gg page.

### Is there an associated suggestion or issue?
This was based on the suggestion by [TheCrossBoy](https://github.com/TheCrossBoy) in #773, where [ScalarVector1](https://github.com/ScalarVector1) approved of the compatibility. After some brief testing it feels like a good QoL improvement to have.

### What are the implementation specifics of this change? Are there any consequences?
The implementation adds another wrapper for Wikithis to have a weak reference to the calls necessary to set it up, however, I'm not sure if there's a more appropriate location to perform this setup call, as it's currently done in `PostSetupContent`.