### PR TITLE
Fix duplicate furniture drops

### DIFF
--- a/Core/Loaders/TileLoading/SimpleTileLoader.cs
+++ b/Core/Loaders/TileLoading/SimpleTileLoader.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.Audio;
+﻿using System.Collections.Generic;
+using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.ID;
 
@@ -194,9 +195,9 @@ namespace StarlightRiver.Core.Loaders.TileLoading
 			return MinPick < 100;
 		}
 
-		public override void KillMultiTile(int i, int j, int frameX, int frameY)
+		public override IEnumerable<Item> GetItemDrops(int i, int j)
 		{
-			Item.NewItem(new EntitySource_TileBreak(i, j), new Vector2(i, j) * 16, DropID);
+			yield return new Item(DropID);
 		}
 	}
 


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
Fixes certain furniture drops being doubled up when broken. Related issue: #455

### What are the implementation specifics of this change? Are there any consequences?
I removed KillMultiTile override since it was legacy code to cover item drops before they were supported for multi blocks. I also added the GetItemDrops override to cover alternative styles