### PR TITLE
Fix Vitric door

### DIFF
--- a/Core/Loaders/TileLoading/FurnitureLoader.cs
+++ b/Core/Loaders/TileLoading/FurnitureLoader.cs
@@ -537,8 +537,8 @@ namespace StarlightRiver.Core.Loaders.TileLoading
 		{
 			Player Player = Main.LocalPlayer;
 			Player.noThrow = 2;
-			//Player.cursorItemIconEnabled = true;
-			//Player.cursorItemIconID = Mod.Find<ModItem>(name.Replace("Closed", "")).Type;
+			Player.cursorItemIconEnabled = true;
+			Player.cursorItemIconID = Mod.Find<ModItem>(name).Type;
 		}
 	}
 
@@ -605,8 +605,8 @@ namespace StarlightRiver.Core.Loaders.TileLoading
 		{
 			Player Player = Main.LocalPlayer;
 			Player.noThrow = 2;
-			//Player.cursorItemIconEnabled = true;
-			//Player.cursorItemIconID = Mod.Find<ModItem>(name.Replace("Open", "")).Type;
+			Player.cursorItemIconEnabled = true;
+			Player.cursorItemIconID = Mod.Find<ModItem>(name.Replace("Open", "Closed")).Type;
 		}
 	}
 

--- a/Core/Loaders/TileLoading/FurnitureLoader.cs
+++ b/Core/Loaders/TileLoading/FurnitureLoader.cs
@@ -549,6 +549,8 @@ namespace StarlightRiver.Core.Loaders.TileLoading
 
 		public override void SetStaticDefaults()
 		{
+			RegisterItemDrop(Mod.Find<ModItem>(name.Replace("Open", "Closed")).Type, 0);
+
 			Main.tileLavaDeath[Type] = true;
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style2xX);
 			TileObjectData.newTile.AnchorTop = new AnchorData(AnchorType.SolidTile, 1, 0);


### PR DESCRIPTION
### What is being fixed or optimized? Is there an associated issue?
Fixes the generic door classes in `FurnitureLoader` to use the appropriate cursor item icon and makes the open door variants drop their corresponding item. Related issue: #512

### What are the implementation specifics of this change? Are there any consequences?
I used `RegisterItemDrop` in order to fix the open door drop, and I fixed the `cursorItemIconID` being invalid which was why the player was freezing in the past when hovering their cursor over the door before.